### PR TITLE
Webhookの実装

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "orjson>=3.10.0",
     "ulid-py>=1.1.0",
     "typer>=0.12.0",
+    "httpx>=0.27.0",
 ]
 
 [project.scripts]

--- a/src/schemaform/models.py
+++ b/src/schemaform/models.py
@@ -18,6 +18,9 @@ class FormModel(Base):
     status = Column(String)
     schema_json = Column(Text)
     field_order = Column(Text)
+    webhook_url = Column(Text, nullable=True)
+    webhook_on_submit = Column(Integer, default=0)
+    webhook_on_delete = Column(Integer, default=0)
     created_at = Column(DateTime)
     updated_at = Column(DateTime)
 

--- a/src/schemaform/repo_json.py
+++ b/src/schemaform/repo_json.py
@@ -97,6 +97,9 @@ class JSONFormRepo(JSONRepoBase):
             "status": record.get("status", "inactive"),
             "schema_json": record.get("schema_json", {}),
             "field_order": record.get("field_order", []),
+            "webhook_url": record.get("webhook_url", ""),
+            "webhook_on_submit": record.get("webhook_on_submit", False),
+            "webhook_on_delete": record.get("webhook_on_delete", False),
             "created_at": parse_dt(record.get("created_at")),
             "updated_at": parse_dt(record.get("updated_at")),
         }

--- a/src/schemaform/repo_json.py
+++ b/src/schemaform/repo_json.py
@@ -112,6 +112,11 @@ class JSONSubmissionRepo(JSONRepoBase):
         submissions = [self._from_record(item) for item in items]
         return sorted(submissions, key=lambda x: x["created_at"], reverse=True)
 
+    def get_submission(self, submission_id: str) -> dict[str, Any] | None:
+        with self._db() as db:
+            items = db.table("submissions").search(Query().id == submission_id)
+        return self._from_record(items[0]) if items else None
+
     def create_submission(self, submission: dict[str, Any]) -> None:
         record = self._to_record(submission)
         with self._db() as db:

--- a/src/schemaform/repo_sqlite.py
+++ b/src/schemaform/repo_sqlite.py
@@ -43,6 +43,9 @@ class SQLiteFormRepo:
                 status=form["status"],
                 schema_json=dumps_json(form["schema_json"]),
                 field_order=dumps_json(form["field_order"]),
+                webhook_url=form.get("webhook_url", ""),
+                webhook_on_submit=1 if form.get("webhook_on_submit") else 0,
+                webhook_on_delete=1 if form.get("webhook_on_delete") else 0,
                 created_at=form["created_at"],
                 updated_at=form["updated_at"],
             )

--- a/src/schemaform/repo_sqlite.py
+++ b/src/schemaform/repo_sqlite.py
@@ -60,6 +60,8 @@ class SQLiteFormRepo:
             for key, value in updates.items():
                 if key in {"schema_json", "field_order"}:
                     setattr(row, key, dumps_json(value))
+                elif key in {"webhook_on_submit", "webhook_on_delete"}:
+                    setattr(row, key, 1 if value else 0)
                 else:
                     setattr(row, key, value)
             session.commit()
@@ -113,6 +115,11 @@ class SQLiteSubmissionRepo:
                 .all()
             )
             return [self._to_dict(row) for row in rows]
+
+    def get_submission(self, submission_id: str) -> dict[str, Any] | None:
+        with self._Session() as session:
+            row = session.get(SubmissionModel, submission_id)
+            return self._to_dict(row) if row else None
 
     def create_submission(self, submission: dict[str, Any]) -> None:
         with self._Session() as session:

--- a/src/schemaform/repo_sqlite.py
+++ b/src/schemaform/repo_sqlite.py
@@ -26,7 +26,11 @@ class SQLiteFormRepo:
 
     def get_form_by_public_id(self, public_id: str) -> dict[str, Any] | None:
         with self._Session() as session:
-            row = session.query(FormModel).filter(FormModel.public_id == public_id).first()
+            row = (
+                session.query(FormModel)
+                .filter(FormModel.public_id == public_id)
+                .first()
+            )
             return self._to_dict(row) if row else None
 
     def create_form(self, form: dict[str, Any]) -> None:
@@ -85,6 +89,9 @@ class SQLiteFormRepo:
             "status": row.status,
             "schema_json": loads_json(row.schema_json) or {},
             "field_order": loads_json(row.field_order) or [],
+            "webhook_url": row.webhook_url or "",
+            "webhook_on_submit": bool(row.webhook_on_submit),
+            "webhook_on_delete": bool(row.webhook_on_delete),
             "created_at": row.created_at,
             "updated_at": row.updated_at,
         }

--- a/src/schemaform/routes/api.py
+++ b/src/schemaform/routes/api.py
@@ -129,7 +129,7 @@ async def api_submit_form(public_id: str, request: Request) -> JSONResponse:
     if form.get("webhook_url") and form.get("webhook_on_submit"):
         from schemaform.webhook import send_webhook
 
-        send_webhook(form["webhook_url"], "submit", form, submission)
+        await send_webhook(form["webhook_url"], "submit", form, submission)
 
     return JSONResponse(
         {"submission_id": submission_id, "created_at": to_iso(created_at)}

--- a/src/schemaform/routes/public.py
+++ b/src/schemaform/routes/public.py
@@ -225,7 +225,7 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
     if form.get("webhook_url") and form.get("webhook_on_submit"):
         from schemaform.webhook import send_webhook
 
-        send_webhook(form["webhook_url"], "submit", form, submission_record)
+        await send_webhook(form["webhook_url"], "submit", form, submission_record)
 
     return templates.TemplateResponse(
         "submission_done.html",

--- a/src/schemaform/routes/public.py
+++ b/src/schemaform/routes/public.py
@@ -36,8 +36,13 @@ async def save_upload(
     file_id = new_ulid()
     destination = settings.upload_dir / file_id
     content = await file_obj.read()
-    if settings.upload_max_bytes is not None and len(content) > settings.upload_max_bytes:
-        raise HTTPException(status_code=400, detail="ファイルサイズが上限を超えています")
+    if (
+        settings.upload_max_bytes is not None
+        and len(content) > settings.upload_max_bytes
+    ):
+        raise HTTPException(
+            status_code=400, detail="ファイルサイズが上限を超えています"
+        )
     destination.write_bytes(content)
     storage.files.create_file(
         {
@@ -118,7 +123,7 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
                     form_prefix = f"{form_key}."
                     for k in form_data:
                         if k.startswith(form_prefix):
-                            rest = k[len(form_prefix):]
+                            rest = k[len(form_prefix) :]
                             parts = rest.split(".", 1)
                             if parts[0].isdigit():
                                 indices.add(int(parts[0]))
@@ -207,14 +212,20 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
             },
         )
 
-    storage.submissions.create_submission(
-        {
-            "id": new_ulid(),
-            "form_id": form["id"],
-            "data_json": submission,
-            "created_at": now_utc(),
-        }
-    )
+    submission_id = new_ulid()
+    created_at = now_utc()
+    submission_record = {
+        "id": submission_id,
+        "form_id": form["id"],
+        "data_json": submission,
+        "created_at": created_at,
+    }
+    storage.submissions.create_submission(submission_record)
+
+    if form.get("webhook_url") and form.get("webhook_on_submit"):
+        from schemaform.webhook import send_webhook
+
+        send_webhook(form["webhook_url"], "submit", form, submission_record)
 
     return templates.TemplateResponse(
         "submission_done.html",

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -169,7 +169,6 @@ async def list_submissions(
         storage, fields
     )
     filter_fields = flatten_filter_fields(fields)
-    display_fields = [column["label"] for column in display_columns]
 
     display_rows = []
     for item in page_items:
@@ -196,7 +195,6 @@ async def list_submissions(
             "request": request,
             "form": form,
             "fields": fields,
-            "display_fields": display_fields,
             "display_columns": display_columns,
             "filter_fields": filter_fields,
             "rows": display_rows,
@@ -217,8 +215,7 @@ async def delete_submission(
 ) -> RedirectResponse:
     storage = request.app.state.storage
     form = storage.forms.get_form(form_id)
-    submission = storage.submissions.list_submissions(form_id)
-    submission_data = next((s for s in submission if s["id"] == submission_id), None)
+    submission_data = storage.submissions.get_submission(submission_id)
 
     storage.submissions.delete_submission(submission_id)
 

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -197,6 +197,7 @@ async def list_submissions(
             "form": form,
             "fields": fields,
             "display_fields": display_fields,
+            "display_columns": display_columns,
             "filter_fields": filter_fields,
             "rows": display_rows,
             "page": page,
@@ -229,7 +230,7 @@ async def delete_submission(
     ):
         from schemaform.webhook import send_webhook
 
-        send_webhook(form["webhook_url"], "delete", form, submission_data)
+        await send_webhook(form["webhook_url"], "delete", form, submission_data)
 
     return RedirectResponse(f"/admin/forms/{form_id}/submissions", status_code=303)
 

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -111,14 +111,18 @@ def build_submission_row_values(
         value = get_nested_value(data, flat_key)
 
         if field.get("type") == "group" and field.get("is_array"):
-            row_values.append(format_array_group_value(value, field.get("children", [])))
+            row_values.append(
+                format_array_group_value(value, field.get("children", []))
+            )
             continue
 
         if field.get("type") == "master":
             lookup = master_lookup_by_field.get(flat_key, {})
             if column["kind"] == "master_display":
                 row_values.append(
-                    render_master_display_text(value, lookup, str(column.get("display_key", "")))
+                    render_master_display_text(
+                        value, lookup, str(column.get("display_key", ""))
+                    )
                 )
             else:
                 row_values.append(render_master_display_text(value, lookup))
@@ -128,8 +132,12 @@ def build_submission_row_values(
     return row_values
 
 
-@router.get("/admin/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["admin"])
-async def list_submissions(request: Request, form_id: str, _: Any = Depends(admin_guard)) -> HTMLResponse:
+@router.get(
+    "/admin/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["admin"]
+)
+async def list_submissions(
+    request: Request, form_id: str, _: Any = Depends(admin_guard)
+) -> HTMLResponse:
     storage = request.app.state.storage
     templates = request.app.state.templates
     form = storage.forms.get_form(form_id)
@@ -157,7 +165,9 @@ async def list_submissions(request: Request, form_id: str, _: Any = Depends(admi
     end = start + page_size
     page_items = filtered[start:end]
 
-    display_columns, master_lookup_by_field = build_submission_display_columns(storage, fields)
+    display_columns, master_lookup_by_field = build_submission_display_columns(
+        storage, fields
+    )
     filter_fields = flatten_filter_fields(fields)
     display_fields = [column["label"] for column in display_columns]
 
@@ -198,17 +208,36 @@ async def list_submissions(request: Request, form_id: str, _: Any = Depends(admi
     )
 
 
-@router.post("/admin/forms/{form_id}/submissions/{submission_id}/delete", tags=["admin"])
+@router.post(
+    "/admin/forms/{form_id}/submissions/{submission_id}/delete", tags=["admin"]
+)
 async def delete_submission(
     request: Request, form_id: str, submission_id: str, _: Any = Depends(admin_guard)
 ) -> RedirectResponse:
     storage = request.app.state.storage
+    form = storage.forms.get_form(form_id)
+    submission = storage.submissions.list_submissions(form_id)
+    submission_data = next((s for s in submission if s["id"] == submission_id), None)
+
     storage.submissions.delete_submission(submission_id)
+
+    if (
+        form
+        and submission_data
+        and form.get("webhook_url")
+        and form.get("webhook_on_delete")
+    ):
+        from schemaform.webhook import send_webhook
+
+        send_webhook(form["webhook_url"], "delete", form, submission_data)
+
     return RedirectResponse(f"/admin/forms/{form_id}/submissions", status_code=303)
 
 
 @router.get("/admin/forms/{form_id}/export", tags=["admin"])
-async def export_submissions(request: Request, form_id: str, _: Any = Depends(admin_guard)) -> PlainTextResponse:
+async def export_submissions(
+    request: Request, form_id: str, _: Any = Depends(admin_guard)
+) -> PlainTextResponse:
     storage = request.app.state.storage
     form = storage.forms.get_form(form_id)
     if not form:
@@ -226,7 +255,9 @@ async def export_submissions(request: Request, form_id: str, _: Any = Depends(ad
     filtered = apply_filters(
         expanded_submissions, fields, dict(request.query_params), file_names=file_names
     )
-    display_columns, master_lookup_by_field = build_submission_display_columns(storage, fields)
+    display_columns, master_lookup_by_field = build_submission_display_columns(
+        storage, fields
+    )
     headers = [column["label"] for column in display_columns]
     rows = [
         build_submission_row_values(

--- a/src/schemaform/schema.py
+++ b/src/schemaform/schema.py
@@ -236,6 +236,9 @@ def sanitize_form_output(form: dict[str, Any]) -> dict[str, Any]:
         "status": form.get("status", "inactive"),
         "schema_json": form.get("schema_json", {}),
         "field_order": form.get("field_order", []),
+        "webhook_url": form.get("webhook_url", ""),
+        "webhook_on_submit": bool(form.get("webhook_on_submit")),
+        "webhook_on_delete": bool(form.get("webhook_on_delete")),
         "created_at": to_iso(form.get("created_at", now_utc())),
         "updated_at": to_iso(form.get("updated_at", now_utc())),
     }

--- a/src/schemaform/webhook.py
+++ b/src/schemaform/webhook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -10,13 +11,20 @@ from schemaform.utils import to_iso
 logger = logging.getLogger(__name__)
 
 
+def is_valid_webhook_url(url: str) -> bool:
+    if not url:
+        return False
+    parsed = urlsplit(url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
 async def send_webhook(
     url: str,
     event: str,
     form: dict[str, Any],
     submission: dict[str, Any] | None = None,
 ) -> bool:
-    if not url:
+    if not is_valid_webhook_url(url):
         return False
 
     payload: dict[str, Any] = {

--- a/src/schemaform/webhook.py
+++ b/src/schemaform/webhook.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from schemaform.utils import to_iso
+
+logger = logging.getLogger(__name__)
+
+
+def send_webhook(
+    url: str,
+    event: str,
+    form: dict[str, Any],
+    submission: dict[str, Any] | None = None,
+) -> bool:
+    if not url:
+        return False
+
+    payload: dict[str, Any] = {
+        "event": event,
+        "form_id": form.get("id"),
+        "form_name": form.get("name"),
+        "form_public_id": form.get("public_id"),
+    }
+
+    if submission:
+        payload["submission_id"] = submission.get("id")
+        payload["data"] = submission.get("data_json", {})
+        if submission.get("created_at"):
+            payload["created_at"] = to_iso(submission["created_at"])
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.post(url, json=payload)
+            response.raise_for_status()
+        logger.info("Webhook sent successfully: %s -> %s", event, url)
+        return True
+    except Exception:
+        logger.exception("Webhook failed: %s -> %s", event, url)
+        return False

--- a/src/schemaform/webhook.py
+++ b/src/schemaform/webhook.py
@@ -10,7 +10,7 @@ from schemaform.utils import to_iso
 logger = logging.getLogger(__name__)
 
 
-def send_webhook(
+async def send_webhook(
     url: str,
     event: str,
     form: dict[str, Any],
@@ -33,8 +33,8 @@ def send_webhook(
             payload["created_at"] = to_iso(submission["created_at"])
 
     try:
-        with httpx.Client(timeout=10.0) as client:
-            response = client.post(url, json=payload)
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(url, json=payload)
             response.raise_for_status()
         logger.info("Webhook sent successfully: %s -> %s", event, url)
         return True

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -46,41 +46,41 @@
     </div>
   </div>
 
-   <div>
-     <div class="flex flex-wrap items-center gap-3">
-       <h2 class="text-lg font-semibold">フィールド</h2>
-     </div>
-     <p class="mt-2 text-sm text-slate-600">キーは自動生成されます。並び替えはドラッグ操作。</p>
+  <div>
+    <div class="flex flex-wrap items-center gap-3">
+      <h2 class="text-lg font-semibold">フィールド</h2>
+    </div>
+    <p class="mt-2 text-sm text-slate-600">キーは自動生成されます。並び替えはドラッグ操作。</p>
 
-     <div id="field-list" class="mt-4 space-y-3"></div>
-     <div class="mt-4 flex justify-start">
-       <button type="button" id="add-field" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">フィールド追加</button>
-     </div>
-   </div>
+    <div id="field-list" class="mt-4 space-y-3"></div>
+    <div class="mt-4 flex justify-start">
+      <button type="button" id="add-field" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">フィールド追加</button>
+    </div>
+  </div>
 
-   <details class="mt-6 rounded border border-slate-200">
-     <summary class="cursor-pointer px-4 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50">高度な設定</summary>
-     <div class="space-y-4 border-t border-slate-200 px-4 py-4">
-       <div class="text-sm font-semibold text-slate-600">Webhook設定</div>
-       <div class="grid gap-4 md:grid-cols-2">
-         <div>
-           <label class="text-sm text-slate-600">Webhook URL</label>
-           <input name="webhook_url" value="{{ form.webhook_url if form else '' }}" type="url" placeholder="https://example.com/webhook" class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm" />
-           <p class="mt-1 text-xs text-slate-500">送信・削除時に通知を送るURL</p>
-         </div>
-         <div class="flex items-start gap-6 pt-6">
-           <label class="flex items-center gap-2 text-sm">
-             <input type="checkbox" name="webhook_on_submit" {% if form and form.webhook_on_submit %}checked{% endif %} />
-             送信時に通知
-           </label>
-           <label class="flex items-center gap-2 text-sm">
-             <input type="checkbox" name="webhook_on_delete" {% if form and form.webhook_on_delete %}checked{% endif %} />
-             削除時に通知
-           </label>
-         </div>
-       </div>
-     </div>
-   </details>
+  <details class="mt-6 rounded border border-slate-200">
+    <summary class="cursor-pointer px-4 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50">高度な設定</summary>
+    <div class="space-y-4 border-t border-slate-200 px-4 py-4">
+      <div class="text-sm font-semibold text-slate-600">Webhook設定</div>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <label class="text-sm text-slate-600">Webhook URL</label>
+          <input name="webhook_url" value="{{ form.webhook_url if form else '' }}" type="url" placeholder="https://example.com/webhook" class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm" />
+          <p class="mt-1 text-xs text-slate-500">送信・削除時に通知を送るURL</p>
+        </div>
+        <div class="flex items-start gap-6 pt-6">
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="webhook_on_submit" {% if form and form.webhook_on_submit %}checked{% endif %} />
+            送信時に通知
+          </label>
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="webhook_on_delete" {% if form and form.webhook_on_delete %}checked{% endif %} />
+            削除時に通知
+          </label>
+        </div>
+      </div>
+    </div>
+  </details>
 
   <input type="hidden" name="fields_json" id="fields_json" value="" />
 

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -46,17 +46,41 @@
     </div>
   </div>
 
-  <div>
-    <div class="flex flex-wrap items-center gap-3">
-      <h2 class="text-lg font-semibold">フィールド</h2>
-    </div>
-    <p class="mt-2 text-sm text-slate-600">キーは自動生成されます。並び替えはドラッグ操作。</p>
+   <div>
+     <div class="flex flex-wrap items-center gap-3">
+       <h2 class="text-lg font-semibold">フィールド</h2>
+     </div>
+     <p class="mt-2 text-sm text-slate-600">キーは自動生成されます。並び替えはドラッグ操作。</p>
 
-    <div id="field-list" class="mt-4 space-y-3"></div>
-    <div class="mt-4 flex justify-start">
-      <button type="button" id="add-field" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">フィールド追加</button>
-    </div>
-  </div>
+     <div id="field-list" class="mt-4 space-y-3"></div>
+     <div class="mt-4 flex justify-start">
+       <button type="button" id="add-field" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">フィールド追加</button>
+     </div>
+   </div>
+
+   <details class="mt-6 rounded border border-slate-200">
+     <summary class="cursor-pointer px-4 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50">高度な設定</summary>
+     <div class="space-y-4 border-t border-slate-200 px-4 py-4">
+       <div class="text-sm font-semibold text-slate-600">Webhook設定</div>
+       <div class="grid gap-4 md:grid-cols-2">
+         <div>
+           <label class="text-sm text-slate-600">Webhook URL</label>
+           <input name="webhook_url" value="{{ form.webhook_url if form else '' }}" type="url" placeholder="https://example.com/webhook" class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm" />
+           <p class="mt-1 text-xs text-slate-500">送信・削除時に通知を送るURL</p>
+         </div>
+         <div class="flex items-start gap-6 pt-6">
+           <label class="flex items-center gap-2 text-sm">
+             <input type="checkbox" name="webhook_on_submit" {% if form and form.webhook_on_submit %}checked{% endif %} />
+             送信時に通知
+           </label>
+           <label class="flex items-center gap-2 text-sm">
+             <input type="checkbox" name="webhook_on_delete" {% if form and form.webhook_on_delete %}checked{% endif %} />
+             削除時に通知
+           </label>
+         </div>
+       </div>
+     </div>
+   </details>
 
   <input type="hidden" name="fields_json" id="fields_json" value="" />
 

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -103,8 +103,8 @@
     <thead class="bg-slate-100 text-left">
       <tr>
         <th class="px-4 py-3">送信日時</th>
-        {% for label in display_fields %}
-        <th class="px-4 py-3">{{ label }}</th>
+        {% for column in display_columns %}
+        <th class="px-4 py-3">{{ column.label }}</th>
         {% endfor %}
         <th class="px-4 py-3">操作</th>
       </tr>
@@ -116,7 +116,23 @@
           <time class="js-local-dt" data-iso="{{ iso_dt(row.created_at) }}">{{ format_dt(row.created_at) }}</time>
         </td>
         {% for value in row["values"] %}
+        {% set column = display_columns[loop.index0] %}
+        {% if column.kind == "default"
+              and column.field.type == "string"
+              and not column.field.is_array
+              and column.field.format == "url"
+              and value %}
+          {% set trimmed = value | trim %}
+          {% if trimmed.startswith("http://") or trimmed.startswith("https://") %}
+          <td class="px-4 py-3">
+            <a href="{{ trimmed }}" target="_blank" rel="noopener noreferrer" class="break-all text-sky-700 underline">{{ value }}</a>
+          </td>
+          {% else %}
+          <td class="px-4 py-3">{{ value }}</td>
+          {% endif %}
+        {% else %}
         <td class="px-4 py-3">{{ value }}</td>
+        {% endif %}
         {% endfor %}
         <td class="px-4 py-3">
           <form method="post" action="/admin/forms/{{ form.id }}/submissions/{{ row.id }}/delete">
@@ -126,7 +142,7 @@
       </tr>
       {% else %}
       <tr>
-        <td colspan="{{ display_fields | length + 2 }}" class="px-4 py-6 text-center text-slate-500">該当データがありません。</td>
+        <td colspan="{{ display_columns | length + 2 }}" class="px-4 py-6 text-center text-slate-500">該当データがありません。</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -147,6 +156,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -554,6 +591,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "fastapi" },
     { name = "filelock" },
+    { name = "httpx" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "orjson" },
@@ -570,6 +608,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "filelock", specifier = ">=3.14.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonschema", specifier = ">=4.22.0" },
     { name = "orjson", specifier = ">=3.10.0" },


### PR DESCRIPTION
## Summary

Issue #1 の対応として、フォーム単位でWebhook送信先を設定する機能を実装しました。

- Webhook URLと通知タイミング（送信時・削除時）をフォームごとに設定可能
- 「高度な設定」セクション内に設定UIを追加
- httpxによるWebhook送信機能を実装

## 変更内容

- `FormModel`に`webhook_url`, `webhook_on_submit`, `webhook_on_delete`カラムを追加
- Webhook送信機能（`webhook.py`）を追加
- 送信時・削除時にWebhookを送信する処理を追加
- フォーム編集画面に「高度な設定」セクションを追加

## テスト方法

1. フォーム作成/編集画面で「高度な設定」を展開
2. Webhook URLと通知タイミングを設定
3. フォームを公開して送信・削除を実施
4. Webhookが送信されることを確認