### PR TITLE
フォーム参照フィールドの展開行対応 (fix #6)

### DIFF
--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -58,6 +58,12 @@ def build_submission_display_columns(
 
         context = build_master_reference_context(storage, field)
         lookup = {row["id"]: row for row in context["records"]}
+        for row in context["records"]:
+            rid = row["id"]
+            if ":" in rid:
+                base_id = rid.rsplit(":", 1)[0]
+                if base_id not in lookup:
+                    lookup[base_id] = row
         master_lookup_by_field[flat_key] = lookup
         display_items = context["display_items"]
 


### PR DESCRIPTION
参照先フォームにexpand_rowsグループ配列がある場合、選択可能な行の単位を
送信一覧ページの展開後の行に合わせるよう修正。

- build_master_reference_contextで参照先の送信データを展開し、展開行ごとに
  複合ID (submission_id:row_index) で個別レコードを生成
- _resolve_single_partで展開済みデータ（dictになったグループ配列）を処理
- _get_submission_by_idで複合IDから展開行データを解決
- validate_master_referencesで複合IDのバリデーション対応
- 後方互換性のため既存の単純IDも引き続き解決可能