### PR TITLE
テーブルにソート機能を実装 (fix #4)

### DIFF
--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -80,7 +80,7 @@ async def list_forms(request: Request, _: Any = Depends(admin_guard)) -> HTMLRes
         forms.sort(key=lambda f: f.get("status") or "", reverse=reverse)
     else:
         sort = "updated_at"
-        forms.sort(key=lambda f: f.get("updated_at") or "", reverse=reverse)
+        forms.sort(key=lambda f: str(f.get("updated_at") or ""), reverse=reverse)
 
     return templates.TemplateResponse(
         "admin_forms.html",

--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -67,9 +67,24 @@ async def list_forms(request: Request, _: Any = Depends(admin_guard)) -> HTMLRes
     storage = request.app.state.storage
     templates = request.app.state.templates
     forms = storage.forms.list_forms()
+
+    sort = request.query_params.get("sort", "updated_at")
+    order = request.query_params.get("order", "desc")
+    if order not in ("asc", "desc"):
+        order = "desc"
+    reverse = order == "desc"
+
+    if sort == "name":
+        forms.sort(key=lambda f: (f.get("name") or "").lower(), reverse=reverse)
+    elif sort == "status":
+        forms.sort(key=lambda f: f.get("status") or "", reverse=reverse)
+    else:
+        sort = "updated_at"
+        forms.sort(key=lambda f: f.get("updated_at") or "", reverse=reverse)
+
     return templates.TemplateResponse(
         "admin_forms.html",
-        {"request": request, "forms": forms},
+        {"request": request, "forms": forms, "sort": sort, "order": order},
     )
 
 

--- a/templates/admin_forms.html
+++ b/templates/admin_forms.html
@@ -12,10 +12,37 @@
   <table class="min-w-full divide-y divide-slate-200 text-sm">
     <thead class="bg-slate-100 text-left">
       <tr>
-        <th class="px-4 py-3">フォーム名</th>
-        <th class="px-4 py-3">状態</th>
+        <th class="px-4 py-3">
+          <a href="?sort=name&order={{ 'desc' if sort == 'name' and order == 'asc' else 'asc' }}" class="group inline-flex items-center gap-1">
+            フォーム名
+            {% if sort == 'name' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+        <th class="px-4 py-3">
+          <a href="?sort=status&order={{ 'desc' if sort == 'status' and order == 'asc' else 'asc' }}" class="group inline-flex items-center gap-1">
+            状態
+            {% if sort == 'status' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
         <th class="px-4 py-3">ページ遷移</th>
-        <th class="px-4 py-3">更新</th>
+        <th class="px-4 py-3">
+          <a href="?sort=updated_at&order={{ 'desc' if sort == 'updated_at' and order == 'asc' else 'asc' }}" class="group inline-flex items-center gap-1">
+            更新
+            {% if sort == 'updated_at' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
         <th class="px-4 py-3">削除</th>
       </tr>
     </thead>

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -20,6 +20,8 @@
       <button type="button" data-action="close-filter-modal" class="rounded border border-slate-300 px-3 py-1.5 text-xs text-slate-700">閉じる</button>
     </div>
     <form id="filter-form" method="get" class="max-h-[80vh] overflow-y-auto p-4">
+      <input type="hidden" name="sort" value="{{ sort }}" />
+      <input type="hidden" name="order" value="{{ order }}" />
       <div class="grid gap-3 md:grid-cols-3">
         <div>
           <label class="text-xs text-slate-500">フリーワード</label>
@@ -102,10 +104,37 @@
   <table class="min-w-full divide-y divide-slate-200 text-sm">
     <thead class="bg-slate-100 text-left">
       <tr>
-        <th class="px-4 py-3">送信日時</th>
-        <th class="px-4 py-3">更新日時</th>
+        <th class="px-4 py-3">
+          <a href="?{{ build_query(query, sort='created_at', order=('desc' if sort == 'created_at' and order == 'asc' else 'asc'), page=1) }}" class="group inline-flex items-center gap-1">
+            送信日時
+            {% if sort == 'created_at' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+        <th class="px-4 py-3">
+          <a href="?{{ build_query(query, sort='updated_at', order=('desc' if sort == 'updated_at' and order == 'asc' else 'asc'), page=1) }}" class="group inline-flex items-center gap-1">
+            更新日時
+            {% if sort == 'updated_at' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
         {% for column in display_columns %}
-        <th class="px-4 py-3">{{ column.label }}</th>
+        <th class="px-4 py-3">
+          <a href="?{{ build_query(query, sort=loop.index0|string, order=('desc' if sort == loop.index0|string and order == 'asc' else 'asc'), page=1) }}" class="group inline-flex items-center gap-1">
+            {{ column.label }}
+            {% if sort == loop.index0|string %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
         {% endfor %}
         <th class="px-4 py-3">操作</th>
       </tr>


### PR DESCRIPTION
フォーム一覧と送信一覧のテーブルヘッダーをクリックすることで
昇順/降順のソートが可能になる。

- フォーム一覧: フォーム名・状態・更新日時でソート可能
- 送信一覧: 送信日時・更新日時・各フィールド列でソート可能
- 数値フィールドは数値としてソート、テキストは辞書順
- ソート状態はページネーション・フィルター・CSV/TSVエクスポートと連携
- ソート変更時はページを1にリセット