### PR TITLE
管理者ページと利用者ページを分離 (fix #11)

### DIFF
--- a/src/schemaform/app.py
+++ b/src/schemaform/app.py
@@ -16,6 +16,7 @@ from schemaform.routes.admin import router as admin_router
 from schemaform.routes.api import router as api_router
 from schemaform.routes.public import router as public_router
 from schemaform.routes.submissions import router as submissions_router
+from schemaform.routes.user import router as user_router
 from schemaform.storage import init_storage
 
 
@@ -103,6 +104,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app = FastAPI(
         openapi_tags=[
             {"name": "admin", "description": "管理画面（HTML）"},
+            {"name": "user", "description": "利用者画面（HTML）"},
             {"name": "public", "description": "公開フォーム（HTML）"},
             {"name": "api/forms", "description": "REST API: フォーム"},
             {"name": "api/submissions", "description": "REST API: 送信"},
@@ -126,6 +128,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     templates.env.globals["build_query"] = build_query
 
     app.include_router(admin_router)
+    app.include_router(user_router)
     app.include_router(public_router)
     app.include_router(submissions_router)
     app.include_router(api_router)

--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -59,7 +59,7 @@ def build_master_field_catalog(
 
 @router.get("/", response_class=HTMLResponse, tags=["admin"])
 async def home(request: Request) -> HTMLResponse:
-    return RedirectResponse("/admin/forms")
+    return RedirectResponse("/forms")
 
 
 @router.get("/admin/forms", response_class=HTMLResponse, tags=["admin"])

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -265,8 +265,16 @@ async def list_submissions(
     order = request.query_params.get("order", "desc")
     sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
 
-    page = int(request.query_params.get("page", 1))
-    page_size = int(request.query_params.get("page_size", 50))
+    try:
+        page = int(request.query_params.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
+    try:
+        page_size = int(request.query_params.get("page_size", 50))
+    except (ValueError, TypeError):
+        page_size = 50
+    page = max(1, page)
+    page_size = max(1, min(page_size, 100))
     total = len(filtered)
     start = (page - 1) * page_size
     end = start + page_size

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from schemaform.fields import (
+    expand_group_array_rows,
+    flatten_filter_fields,
+)
+from schemaform.filters import (
+    apply_filters,
+    collect_file_ids,
+    resolve_file_names,
+)
+from schemaform.routes.submissions import (
+    build_submission_display_columns,
+    build_submission_row_values,
+    sort_submissions,
+)
+from schemaform.schema import fields_from_schema
+
+router = APIRouter()
+
+
+@router.get("/forms", response_class=HTMLResponse, tags=["user"])
+async def list_forms(request: Request) -> HTMLResponse:
+    storage = request.app.state.storage
+    templates = request.app.state.templates
+    forms = storage.forms.list_forms()
+
+    active_forms = [f for f in forms if f.get("status") == "active"]
+
+    sort = request.query_params.get("sort", "updated_at")
+    order = request.query_params.get("order", "desc")
+    if order not in ("asc", "desc"):
+        order = "desc"
+    reverse = order == "desc"
+
+    if sort == "name":
+        active_forms.sort(key=lambda f: (f.get("name") or "").lower(), reverse=reverse)
+    else:
+        sort = "updated_at"
+        active_forms.sort(
+            key=lambda f: str(f.get("updated_at") or ""), reverse=reverse
+        )
+
+    return templates.TemplateResponse(
+        "forms.html",
+        {
+            "request": request,
+            "forms": active_forms,
+            "sort": sort,
+            "order": order,
+        },
+    )
+
+
+@router.get(
+    "/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["user"]
+)
+async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
+    storage = request.app.state.storage
+    templates = request.app.state.templates
+    form = storage.forms.get_form(form_id)
+    if not form:
+        raise HTTPException(status_code=404, detail="フォームが見つかりません")
+
+    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
+    submissions = storage.submissions.list_submissions(form_id)
+    expanded_submissions: list[dict[str, Any]] = []
+    for submission in submissions:
+        data = submission.get("data_json", {})
+        for expanded_data in expand_group_array_rows(fields, data):
+            expanded_submissions.append({**submission, "data_json": expanded_data})
+    file_ids = collect_file_ids(submissions, fields)
+    file_names = resolve_file_names(storage.files, file_ids)
+
+    filtered = apply_filters(
+        expanded_submissions,
+        fields,
+        dict(request.query_params),
+        file_names=file_names,
+    )
+
+    display_columns, master_lookup_by_field = build_submission_display_columns(
+        storage, fields
+    )
+
+    sort = request.query_params.get("sort", "created_at")
+    order = request.query_params.get("order", "desc")
+    sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
+
+    page = int(request.query_params.get("page", 1))
+    page_size = int(request.query_params.get("page_size", 50))
+    total = len(filtered)
+    start = (page - 1) * page_size
+    end = start + page_size
+    page_items = filtered[start:end]
+
+    filter_fields = flatten_filter_fields(fields)
+
+    display_rows = []
+    for item in page_items:
+        data = item.get("data_json", {})
+        row_values = build_submission_row_values(
+            data,
+            display_columns,
+            master_lookup_by_field,
+            file_names,
+        )
+        display_rows.append(
+            {
+                "id": item["id"],
+                "created_at": item["created_at"],
+                "updated_at": item.get("updated_at"),
+                "values": row_values,
+            }
+        )
+
+    total_pages = max(1, (total + page_size - 1) // page_size)
+
+    return templates.TemplateResponse(
+        "user_submissions.html",
+        {
+            "request": request,
+            "form": form,
+            "fields": fields,
+            "display_columns": display_columns,
+            "filter_fields": filter_fields,
+            "rows": display_rows,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "total_pages": total_pages,
+            "query": dict(request.query_params),
+            "sort": sort,
+            "order": order,
+        },
+    )

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -92,8 +92,16 @@ async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
     order = request.query_params.get("order", "desc")
     sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
 
-    page = int(request.query_params.get("page", 1))
-    page_size = int(request.query_params.get("page_size", 50))
+    try:
+        page = int(request.query_params.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
+    try:
+        page_size = int(request.query_params.get("page_size", 50))
+    except (ValueError, TypeError):
+        page_size = 50
+    page = max(1, page)
+    page_size = max(1, min(page_size, 100))
     total = len(filtered)
     start = (page - 1) * page_size
     end = start + page_size

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,9 +68,10 @@
   <body class="min-h-screen bg-slate-50 text-slate-900">
     <header class="border-b border-slate-200 bg-white">
       <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-        <a href="/admin/forms" class="text-lg font-semibold">SchemaForm</a>
+        <a href="/forms" class="text-lg font-semibold">SchemaForm</a>
         <nav class="flex gap-3 text-sm text-slate-600">
-          <a href="/admin/forms" class="hover:text-slate-900">フォーム一覧</a>
+          <a href="/forms" class="hover:text-slate-900">フォーム一覧</a>
+          <a href="/admin/forms" class="hover:text-slate-900">管理</a>
         </nav>
       </div>
     </header>

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="flex flex-wrap items-center justify-between gap-3">
+  <div>
+    <h1 class="text-2xl font-semibold">フォーム一覧</h1>
+    <p class="text-sm text-slate-600">公開中のフォームを確認できます。</p>
+  </div>
+</div>
+
+<div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">
+  <table class="min-w-full divide-y divide-slate-200 text-sm">
+    <thead class="bg-slate-100 text-left">
+      <tr>
+        <th class="px-4 py-3">
+          <a href="?sort=name&order={{ 'desc' if sort == 'name' and order == 'asc' else 'asc' }}" class="group inline-flex items-center gap-1">
+            フォーム名
+            {% if sort == 'name' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+        <th class="px-4 py-3">ページ遷移</th>
+        <th class="px-4 py-3">
+          <a href="?sort=updated_at&order={{ 'desc' if sort == 'updated_at' and order == 'asc' else 'asc' }}" class="group inline-flex items-center gap-1">
+            更新
+            {% if sort == 'updated_at' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-200">
+      {% for form in forms %}
+      <tr>
+        <td class="px-4 py-3 font-medium">
+          <div class="whitespace-nowrap text-slate-900">{{ form.name }}</div>
+          <div class="text-xs text-slate-500">{{ form.description }}</div>
+        </td>
+        <td class="px-4 py-3">
+          <div class="flex flex-nowrap gap-2 whitespace-nowrap">
+            <a href="/f/{{ form.public_id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">入力</a>
+            <a href="/forms/{{ form.id }}/submissions" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">一覧</a>
+          </div>
+        </td>
+        <td class="px-4 py-3 text-slate-600">
+          <time class="js-local-dt" data-iso="{{ iso_dt(form.updated_at) }}">{{ format_dt(form.updated_at) }}</time>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="3" class="px-4 py-6 text-center text-slate-500">公開中のフォームがありません。</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/submission_done.html
+++ b/templates/submission_done.html
@@ -5,7 +5,7 @@
   <p class="mt-2 text-sm text-slate-600">{{ form.name }} への回答を受け付けました。</p>
   <div class="mt-4 flex gap-3">
     <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-4 py-2 text-sm">もう一度入力</a>
-    <a href="/admin/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-4 py-2 text-sm">送信一覧</a>
+    <a href="/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-4 py-2 text-sm">送信一覧</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/user_submissions.html
+++ b/templates/user_submissions.html
@@ -1,0 +1,281 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="flex flex-wrap items-center justify-between gap-3">
+  <div>
+    <h1 class="text-2xl font-semibold">送信一覧</h1>
+    <p class="text-sm text-slate-600">{{ form.name }} の送信内容を確認します。</p>
+  </div>
+  <div class="flex gap-2">
+    <button type="button" id="open-filter-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">フィルター</button>
+    <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-3 py-2 text-sm">入力ページ</a>
+  </div>
+</div>
+
+<div id="filter-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/50 px-4 py-6">
+  <div class="w-full max-w-5xl rounded-lg border border-slate-200 bg-white shadow-xl">
+    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+      <h2 class="text-base font-semibold text-slate-900">フィルター条件</h2>
+      <button type="button" data-action="close-filter-modal" class="rounded border border-slate-300 px-3 py-1.5 text-xs text-slate-700">閉じる</button>
+    </div>
+    <form id="filter-form" method="get" class="max-h-[80vh] overflow-y-auto p-4">
+      <input type="hidden" name="sort" value="{{ sort }}" />
+      <input type="hidden" name="order" value="{{ order }}" />
+      <div class="grid gap-3 md:grid-cols-3">
+        <div>
+          <label class="text-xs text-slate-500">フリーワード</label>
+          <input name="q" value="{{ query.get('q', '') }}" class="mt-1 w-full rounded border border-slate-300 px-2 py-2 text-sm" placeholder="検索ワード" />
+        </div>
+        <div>
+          <label class="text-xs text-slate-500">送信日時 (From)</label>
+          <input name="submitted_from" value="{{ query.get('submitted_from', '') }}" data-picker="datetime-local" class="mt-1 w-full rounded border border-slate-300 px-2 py-2 text-sm" placeholder="開始日時" />
+        </div>
+        <div>
+          <label class="text-xs text-slate-500">送信日時 (To)</label>
+          <input name="submitted_to" value="{{ query.get('submitted_to', '') }}" data-picker="datetime-local" class="mt-1 w-full rounded border border-slate-300 px-2 py-2 text-sm" placeholder="終了日時" />
+        </div>
+      </div>
+
+      <div class="mt-3 grid gap-3 md:grid-cols-3">
+        <div>
+          <label class="text-xs text-slate-500">ページサイズ</label>
+          <select name="page_size" class="mt-1 w-full rounded border border-slate-300 px-2 py-2 text-sm">
+            {% for size in [20, 50, 100] %}
+            <option value="{{ size }}" {% if page_size == size %}selected{% endif %}>{{ size }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="mt-4 grid gap-3 md:grid-cols-3">
+        {% for field in filter_fields %}
+        {% set param_key = 'f_' ~ field.flat_key | replace('.', '__') %}
+        <div class="rounded border border-slate-100 bg-slate-50 p-3">
+          <div class="text-xs font-semibold text-slate-500">{{ field.flat_label }}</div>
+          {% if field.type == 'group' and field.is_array %}
+            <input name="{{ param_key }}" value="{{ query.get(param_key, '') }}" class="mt-2 w-full rounded border border-slate-300 px-2 py-1 text-sm" placeholder="含む値" />
+          {% elif field.is_array %}
+            {% if field.type == 'enum' %}
+            <select name="{{ param_key }}" class="mt-2 w-full rounded border border-slate-300 px-2 py-1 text-sm">
+              <option value="">指定なし</option>
+              {% for option in field.enum %}
+              <option value="{{ option }}" {% if query.get(param_key) == option %}selected{% endif %}>{{ option }}</option>
+              {% endfor %}
+            </select>
+            {% else %}
+            <input name="{{ param_key }}" value="{{ query.get(param_key, '') }}" class="mt-2 w-full rounded border border-slate-300 px-2 py-1 text-sm" placeholder="含む値" />
+            {% endif %}
+          {% elif field.type in ['number', 'integer'] %}
+            <div class="mt-2 grid gap-2">
+              <input name="{{ param_key }}_min" value="{{ query.get(param_key ~ '_min', '') }}" class="w-full rounded border border-slate-300 px-2 py-1 text-sm" placeholder="min" />
+              <input name="{{ param_key }}_max" value="{{ query.get(param_key ~ '_max', '') }}" class="w-full rounded border border-slate-300 px-2 py-1 text-sm" placeholder="max" />
+            </div>
+          {% elif field.type == 'boolean' %}
+            <select name="{{ param_key }}" class="mt-2 w-full rounded border border-slate-300 px-2 py-1 text-sm">
+              <option value="" {% if query.get(param_key, '') == '' %}selected{% endif %}>指定なし</option>
+              <option value="true" {% if query.get(param_key) == 'true' %}selected{% endif %}>true</option>
+              <option value="false" {% if query.get(param_key) == 'false' %}selected{% endif %}>false</option>
+            </select>
+          {% elif field.type == 'enum' %}
+            <select name="{{ param_key }}" class="mt-2 w-full rounded border border-slate-300 px-2 py-1 text-sm">
+              <option value="">指定なし</option>
+              {% for option in field.enum %}
+              <option value="{{ option }}" {% if query.get(param_key) == option %}selected{% endif %}>{{ option }}</option>
+              {% endfor %}
+            </select>
+          {% else %}
+            <input name="{{ param_key }}" value="{{ query.get(param_key, '') }}" class="mt-2 w-full rounded border border-slate-300 px-2 py-1 text-sm" placeholder="含む値" />
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+
+      <div class="mt-4 flex gap-2 border-t border-slate-200 pt-4">
+        <button type="submit" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">検索</button>
+        <a href="/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-3 py-2 text-sm">リセット</a>
+        <button type="button" data-action="close-filter-modal" class="ml-auto rounded border border-slate-300 px-3 py-2 text-sm">閉じる</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">
+  <table class="min-w-full divide-y divide-slate-200 text-sm">
+    <thead class="bg-slate-100 text-left">
+      <tr>
+        <th class="px-4 py-3">
+          <a href="?{{ build_query(query, sort='created_at', order=('desc' if sort == 'created_at' and order == 'asc' else 'asc'), page=1) }}" class="group inline-flex items-center gap-1">
+            送信日時
+            {% if sort == 'created_at' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+        <th class="px-4 py-3">
+          <a href="?{{ build_query(query, sort='updated_at', order=('desc' if sort == 'updated_at' and order == 'asc' else 'asc'), page=1) }}" class="group inline-flex items-center gap-1">
+            更新日時
+            {% if sort == 'updated_at' %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+        {% for column in display_columns %}
+        <th class="px-4 py-3">
+          <a href="?{{ build_query(query, sort=loop.index0|string, order=('desc' if sort == loop.index0|string and order == 'asc' else 'asc'), page=1) }}" class="group inline-flex items-center gap-1">
+            {{ column.label }}
+            {% if sort == loop.index0|string %}
+            <span class="text-slate-400">{{ '▲' if order == 'asc' else '▼' }}</span>
+            {% else %}
+            <span class="text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity">▲</span>
+            {% endif %}
+          </a>
+        </th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-200">
+      {% for row in rows %}
+      <tr>
+        <td class="px-4 py-3 text-slate-600">
+          <time class="js-local-dt" data-iso="{{ iso_dt(row.created_at) }}">{{ format_dt(row.created_at) }}</time>
+        </td>
+        <td class="px-4 py-3 text-slate-600">
+          {% if row.updated_at %}
+          <time class="js-local-dt" data-iso="{{ iso_dt(row.updated_at) }}">{{ format_dt(row.updated_at) }}</time>
+          {% else %}
+          -
+          {% endif %}
+        </td>
+        {% for value in row["values"] %}
+        {% set column = display_columns[loop.index0] %}
+        {% if column.kind == "default"
+              and column.field.type == "string"
+              and (
+                column.field.format == "url"
+                or "http://" in value
+                or "https://" in value
+                or "www." in value
+              )
+              and value %}
+          <td class="px-4 py-3">
+            {% set raw_items = value.split(",") if column.field.is_array else [value] %}
+            {% for raw_item in raw_items %}
+              {% set trimmed = raw_item | trim %}
+              {% if trimmed %}
+                {% if trimmed.startswith("http://") or trimmed.startswith("https://") %}
+                  <a href="{{ trimmed }}" target="_blank" rel="noopener noreferrer" class="break-all text-sky-700 underline">{{ trimmed }}</a>
+                {% elif trimmed.startswith("www.") %}
+                  <a href="https://{{ trimmed }}" target="_blank" rel="noopener noreferrer" class="break-all text-sky-700 underline">{{ trimmed }}</a>
+                {% else %}
+                  {{ trimmed }}
+                {% endif %}
+                {% if not loop.last %}, {% endif %}
+              {% endif %}
+            {% endfor %}
+          </td>
+        {% else %}
+        <td class="px-4 py-3">{{ value }}</td>
+        {% endif %}
+        {% endfor %}
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="{{ display_columns | length + 2 }}" class="px-4 py-6 text-center text-slate-500">該当データがありません。</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="mt-4 flex items-center justify-between text-sm">
+  <div class="text-slate-500">{{ total }}件中 {{ (page - 1) * page_size + 1 if total > 0 else 0 }}-{{ [page * page_size, total] | min }}件</div>
+  <div class="flex gap-2">
+    {% if page > 1 %}
+    <a href="?{{ build_query(query, page=page-1) }}" class="rounded border border-slate-300 px-3 py-1">前へ</a>
+    {% endif %}
+    <span class="rounded border border-slate-300 px-3 py-1">{{ page }} / {{ total_pages }}</span>
+    {% if page < total_pages %}
+    <a href="?{{ build_query(query, page=page+1) }}" class="rounded border border-slate-300 px-3 py-1">次へ</a>
+    {% endif %}
+  </div>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const openFilterButton = document.getElementById("open-filter-modal");
+    const filterModal = document.getElementById("filter-modal");
+    const closeFilterButtons = Array.from(
+      document.querySelectorAll('[data-action="close-filter-modal"]')
+    );
+
+    function openFilterModal() {
+      if (!filterModal) return;
+      filterModal.classList.remove("hidden");
+      filterModal.classList.add("flex");
+      document.body.classList.add("overflow-hidden");
+    }
+
+    function closeFilterModal() {
+      if (!filterModal) return;
+      filterModal.classList.add("hidden");
+      filterModal.classList.remove("flex");
+      document.body.classList.remove("overflow-hidden");
+    }
+
+    openFilterButton?.addEventListener("click", openFilterModal);
+    closeFilterButtons.forEach((button) => {
+      button.addEventListener("click", closeFilterModal);
+    });
+    filterModal?.addEventListener("click", (event) => {
+      if (event.target === filterModal) {
+        closeFilterModal();
+      }
+    });
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        closeFilterModal();
+      }
+    });
+
+    if (typeof flatpickr === "undefined") return;
+    const form = document.getElementById("filter-form");
+    const pickerInputs = document.querySelectorAll("input[data-picker=\"datetime-local\"]");
+
+    pickerInputs.forEach((input) => {
+      const raw = input.value;
+      const options = {
+        enableTime: true,
+        dateFormat: "Y-m-d\\TH:i",
+        altInput: true,
+        altFormat: "Y/m/d H:i",
+        time_24hr: true,
+        locale: "ja",
+      };
+      const parsed = raw ? new Date(raw) : null;
+      if (parsed && !Number.isNaN(parsed.getTime())) {
+        options.defaultDate = parsed;
+      } else {
+        input.value = "";
+      }
+      flatpickr(input, options);
+    });
+
+    if (form) {
+      form.addEventListener("submit", () => {
+        pickerInputs.forEach((input) => {
+          if (!input.value) return;
+          const date = new Date(input.value);
+          if (Number.isNaN(date.getTime())) {
+            input.value = "";
+            return;
+          }
+          input.value = date.toISOString().replace("Z", "+00:00");
+        });
+      });
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
一般利用者向けの読み取り専用ページを新設し、送信完了後やナビゲーションから
管理者ページへ直接遷移しないよう修正。管理者専用の操作（削除・編集・公開/停止）は
引き続き /admin/ 配下のみに制限される。

- GET /forms: 公開中フォーム一覧（読み取り専用）
- GET /forms/{form_id}/submissions: 送信一覧（読み取り専用）
- ヘッダーナビゲーションのデフォルト遷移先を /forms に変更
- 管理ページへは「管理」リンクからアクセス可能