### PR TITLE
送信一覧のファイル取り込み機能を追加 (fix #13)

### DIFF
--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -613,11 +614,36 @@ def _build_import_field_map(
     return mapping
 
 
+def _wrap_arrays_from_schema(
+    fields: list[dict[str, Any]], data: dict[str, Any]
+) -> None:
+    """Wrap dict values into single-element lists for array group fields."""
+    for field in fields:
+        key = field["key"]
+        if key not in data:
+            continue
+        if field.get("type") == "group":
+            if field.get("is_array"):
+                if isinstance(data[key], dict):
+                    data[key] = [data[key]]
+            else:
+                children = field.get("children") or []
+                if isinstance(data[key], dict) and children:
+                    _wrap_arrays_from_schema(children, data[key])
+
+
 def _convert_cell_value(raw: str, field: dict[str, Any]) -> Any:
     """Convert a raw CSV cell string to the appropriate Python type."""
     field_type = field.get("type", "string")
     if raw == "":
         return None
+    if field.get("is_array") or field_type == "group":
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
     if field_type in ("number", "integer"):
         return normalize_number(raw, field_type == "integer")
     if field_type == "boolean":
@@ -694,6 +720,7 @@ async def import_submissions(
             if value is not None:
                 set_nested_value(data, flat_key, value)
 
+        _wrap_arrays_from_schema(fields, data)
         data = clean_empty_recursive(data) or {}
         if not data:
             continue

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -14,6 +14,7 @@ from schemaform.fields import (
     flatten_filter_fields,
     format_array_group_value,
     get_nested_value,
+    set_nested_value,
 )
 from schemaform.filters import (
     apply_filters,
@@ -29,6 +30,7 @@ from schemaform.master import (
     validate_master_references,
 )
 from schemaform.schema import fields_from_schema
+from schemaform.utils import new_ulid, now_utc
 
 router = APIRouter()
 
@@ -597,6 +599,112 @@ async def export_submissions(
         media_type=content_type,
         headers={"Content-Disposition": f"attachment; filename={filename}"},
     )
+
+
+def _build_import_field_map(
+    fields: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Build a mapping from label/key to flat field info for CSV import."""
+    flat_fields = flatten_fields(fields)
+    mapping: dict[str, dict[str, Any]] = {}
+    for field in flat_fields:
+        mapping[field["flat_label"]] = field
+        mapping[field["flat_key"]] = field
+    return mapping
+
+
+def _convert_cell_value(raw: str, field: dict[str, Any]) -> Any:
+    """Convert a raw CSV cell string to the appropriate Python type."""
+    field_type = field.get("type", "string")
+    if raw == "":
+        return None
+    if field_type in ("number", "integer"):
+        return normalize_number(raw, field_type == "integer")
+    if field_type == "boolean":
+        return parse_bool(raw)
+    return raw
+
+
+@router.post(
+    "/admin/forms/{form_id}/import", tags=["admin"]
+)
+async def import_submissions(
+    request: Request, form_id: str, _: Any = Depends(admin_guard)
+) -> RedirectResponse:
+    storage = request.app.state.storage
+    form = storage.forms.get_form(form_id)
+    if not form:
+        raise HTTPException(status_code=404, detail="フォームが見つかりません")
+
+    form_data = await request.form()
+    upload = form_data.get("file")
+    if not upload or not getattr(upload, "filename", ""):
+        raise HTTPException(status_code=400, detail="ファイルを選択してください")
+
+    content = await upload.read()
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        try:
+            text = content.decode("shift_jis")
+        except UnicodeDecodeError:
+            raise HTTPException(
+                status_code=400, detail="ファイルのエンコーディングを認識できません"
+            )
+
+    filename = getattr(upload, "filename", "") or ""
+    if filename.lower().endswith(".tsv"):
+        delimiter = "\t"
+    else:
+        delimiter = ","
+
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+    try:
+        headers = next(reader)
+    except StopIteration:
+        raise HTTPException(status_code=400, detail="ファイルが空です")
+
+    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
+    field_map = _build_import_field_map(fields)
+
+    col_field_map: list[dict[str, Any] | None] = []
+    for header in headers:
+        header_stripped = header.strip()
+        col_field_map.append(field_map.get(header_stripped))
+
+    now = now_utc()
+    imported_count = 0
+    for row in reader:
+        if not any(cell.strip() for cell in row):
+            continue
+        data: dict[str, Any] = {}
+        for col_idx, cell in enumerate(row):
+            if col_idx >= len(col_field_map):
+                break
+            field_info = col_field_map[col_idx]
+            if field_info is None:
+                continue
+            flat_key = field_info["flat_key"]
+            value = _convert_cell_value(cell.strip(), field_info)
+            if value is not None:
+                set_nested_value(data, flat_key, value)
+
+        data = clean_empty_recursive(data) or {}
+        if not data:
+            continue
+
+        submission_id = new_ulid()
+        storage.submissions.create_submission(
+            {
+                "id": submission_id,
+                "form_id": form_id,
+                "data_json": data,
+                "created_at": now,
+            }
+        )
+        imported_count += 1
+
+    return RedirectResponse(f"/admin/forms/{form_id}/submissions", status_code=303)
 
 
 @router.get("/healthz", tags=["system"])

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -605,7 +605,7 @@ def _build_import_field_map(
     fields: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
     """Build a mapping from label/key to flat field info for CSV import."""
-    flat_fields = flatten_fields(fields)
+    flat_fields = flatten_fields(fields, expand_rows_for_group_arrays=True)
     mapping: dict[str, dict[str, Any]] = {}
     for field in flat_fields:
         mapping[field["flat_label"]] = field
@@ -631,6 +631,8 @@ def _convert_cell_value(raw: str, field: dict[str, Any]) -> Any:
 async def import_submissions(
     request: Request, form_id: str, _: Any = Depends(admin_guard)
 ) -> RedirectResponse:
+    from jsonschema import Draft7Validator
+
     storage = request.app.state.storage
     form = storage.forms.get_form(form_id)
     if not form:
@@ -672,8 +674,11 @@ async def import_submissions(
         header_stripped = header.strip()
         col_field_map.append(field_map.get(header_stripped))
 
+    validator = Draft7Validator(form["schema_json"])
+
     now = now_utc()
     imported_count = 0
+    skipped_count = 0
     for row in reader:
         if not any(cell.strip() for cell in row):
             continue
@@ -691,6 +696,12 @@ async def import_submissions(
 
         data = clean_empty_recursive(data) or {}
         if not data:
+            continue
+
+        schema_errors = list(validator.iter_errors(data))
+        master_errors = validate_master_references(storage, fields, data)
+        if schema_errors or master_errors:
+            skipped_count += 1
             continue
 
         submission_id = new_ulid()

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -7,6 +7,7 @@
   </div>
   <div class="flex gap-2">
     <button type="button" id="open-filter-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">フィルター</button>
+    <button type="button" id="open-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">取り込み</button>
     <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-3 py-2 text-sm">入力ページ</a>
     <a href="/admin/forms/{{ form.id }}/export?{{ build_query(query, format='csv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">CSV</a>
     <a href="/admin/forms/{{ form.id }}/export?{{ build_query(query, format='tsv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">TSV</a>
@@ -95,6 +96,23 @@
         <button type="submit" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">検索</button>
         <a href="/admin/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-3 py-2 text-sm">リセット</a>
         <button type="button" data-action="close-filter-modal" class="ml-auto rounded border border-slate-300 px-3 py-2 text-sm">閉じる</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div id="import-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/50 px-4 py-6">
+  <div class="w-full max-w-md rounded-lg border border-slate-200 bg-white shadow-xl">
+    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+      <h2 class="text-base font-semibold text-slate-900">ファイル取り込み</h2>
+      <button type="button" data-action="close-import-modal" class="rounded border border-slate-300 px-3 py-1.5 text-xs text-slate-700">閉じる</button>
+    </div>
+    <form method="post" action="/admin/forms/{{ form.id }}/import" enctype="multipart/form-data" class="p-4">
+      <p class="text-sm text-slate-600">CSV または TSV ファイルを選択してください。ヘッダー行のラベルがフォームのフィールドに対応します。</p>
+      <input type="file" name="file" accept=".csv,.tsv" required class="mt-3 w-full rounded border border-slate-300 px-2 py-2 text-sm" />
+      <div class="mt-4 flex gap-2 border-t border-slate-200 pt-4">
+        <button type="submit" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">取り込み</button>
+        <button type="button" data-action="close-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">キャンセル</button>
       </div>
     </form>
   </div>
@@ -245,9 +263,41 @@
         closeFilterModal();
       }
     });
+
+    const openImportButton = document.getElementById("open-import-modal");
+    const importModal = document.getElementById("import-modal");
+    const closeImportButtons = Array.from(
+      document.querySelectorAll('[data-action="close-import-modal"]')
+    );
+
+    function openImportModal() {
+      if (!importModal) return;
+      importModal.classList.remove("hidden");
+      importModal.classList.add("flex");
+      document.body.classList.add("overflow-hidden");
+    }
+
+    function closeImportModal() {
+      if (!importModal) return;
+      importModal.classList.add("hidden");
+      importModal.classList.remove("flex");
+      document.body.classList.remove("overflow-hidden");
+    }
+
+    openImportButton?.addEventListener("click", openImportModal);
+    closeImportButtons.forEach((button) => {
+      button.addEventListener("click", closeImportModal);
+    });
+    importModal?.addEventListener("click", (event) => {
+      if (event.target === importModal) {
+        closeImportModal();
+      }
+    });
+
     document.addEventListener("keydown", (event) => {
       if (event.key === "Escape") {
         closeFilterModal();
+        closeImportModal();
       }
     });
 

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -7,7 +7,10 @@
   </div>
   <div class="flex gap-2">
     <button type="button" id="open-filter-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">フィルター</button>
-    <button type="button" id="open-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">取り込み</button>
+    <form id="import-form" method="post" action="/admin/forms/{{ form.id }}/import" enctype="multipart/form-data" class="inline">
+      <input type="file" id="import-file-input" name="file" accept=".csv,.tsv" required class="hidden" />
+      <button type="button" id="open-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">取り込み</button>
+    </form>
     <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-3 py-2 text-sm">入力ページ</a>
     <a href="/admin/forms/{{ form.id }}/export?{{ build_query(query, format='csv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">CSV</a>
     <a href="/admin/forms/{{ form.id }}/export?{{ build_query(query, format='tsv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">TSV</a>
@@ -101,22 +104,6 @@
   </div>
 </div>
 
-<div id="import-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/50 px-4 py-6">
-  <div class="w-full max-w-md rounded-lg border border-slate-200 bg-white shadow-xl">
-    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-      <h2 class="text-base font-semibold text-slate-900">ファイル取り込み</h2>
-      <button type="button" data-action="close-import-modal" class="rounded border border-slate-300 px-3 py-1.5 text-xs text-slate-700">閉じる</button>
-    </div>
-    <form method="post" action="/admin/forms/{{ form.id }}/import" enctype="multipart/form-data" class="p-4">
-      <p class="text-sm text-slate-600">CSV または TSV ファイルを選択してください。ヘッダー行のラベルがフォームのフィールドに対応します。</p>
-      <input type="file" name="file" accept=".csv,.tsv" required class="mt-3 w-full rounded border border-slate-300 px-2 py-2 text-sm" />
-      <div class="mt-4 flex gap-2 border-t border-slate-200 pt-4">
-        <button type="submit" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">取り込み</button>
-        <button type="button" data-action="close-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">キャンセル</button>
-      </div>
-    </form>
-  </div>
-</div>
 
 <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">
   <table class="min-w-full divide-y divide-slate-200 text-sm">
@@ -265,39 +252,21 @@
     });
 
     const openImportButton = document.getElementById("open-import-modal");
-    const importModal = document.getElementById("import-modal");
-    const closeImportButtons = Array.from(
-      document.querySelectorAll('[data-action="close-import-modal"]')
-    );
+    const importFileInput = document.getElementById("import-file-input");
+    const importForm = document.getElementById("import-form");
 
-    function openImportModal() {
-      if (!importModal) return;
-      importModal.classList.remove("hidden");
-      importModal.classList.add("flex");
-      document.body.classList.add("overflow-hidden");
-    }
-
-    function closeImportModal() {
-      if (!importModal) return;
-      importModal.classList.add("hidden");
-      importModal.classList.remove("flex");
-      document.body.classList.remove("overflow-hidden");
-    }
-
-    openImportButton?.addEventListener("click", openImportModal);
-    closeImportButtons.forEach((button) => {
-      button.addEventListener("click", closeImportModal);
+    openImportButton?.addEventListener("click", () => {
+      importFileInput?.click();
     });
-    importModal?.addEventListener("click", (event) => {
-      if (event.target === importModal) {
-        closeImportModal();
+    importFileInput?.addEventListener("change", () => {
+      if (importFileInput.files.length > 0) {
+        importForm?.submit();
       }
     });
 
     document.addEventListener("keydown", (event) => {
       if (event.key === "Escape") {
         closeFilterModal();
-        closeImportModal();
       }
     });
 


### PR DESCRIPTION
管理者画面の送信一覧ページにCSV/TSVファイルからの一括取り込み機能を実装。
ヘッダー行のラベルまたはキーでフィールドを自動マッピングし、
各行を送信データとして登録する。