### PR TITLE
計算フィールドの追加 (fix #15)

### DIFF
--- a/src/schemaform/calculated.py
+++ b/src/schemaform/calculated.py
@@ -4,9 +4,23 @@ import ast
 import re
 from typing import Any
 
+# 内部用: キーベースの参照パターン (評価時に使用)
 FIELD_REF_PATTERN = re.compile(r"\{([A-Za-z][A-Za-z0-9_.]*)\}")
 
+# ユーザー入力用: ラベル等あらゆる文字を許容する参照パターン
+DISPLAY_REF_PATTERN = re.compile(r"\{([^}]+)\}")
+
 AGGREGATE_FUNCTIONS = {"sum", "avg", "count", "max", "min"}
+
+# 内部用: キーベースの集約パターン
+AGGREGATE_CALL_PATTERN = re.compile(
+    r"(sum|avg|count|max|min)\(\{([A-Za-z][A-Za-z0-9_.]*)\}\)"
+)
+
+# ユーザー入力用: ラベルベースの集約パターン
+DISPLAY_AGGREGATE_PATTERN = re.compile(
+    r"(sum|avg|count|max|min)\(\{([^}]+)\}\)"
+)
 
 
 def extract_field_refs(formula: str) -> list[str]:
@@ -56,11 +70,6 @@ def _apply_aggregate(func_name: str, values: list[float]) -> float | None:
     if func_name == "min":
         return min(values)
     return None
-
-
-AGGREGATE_CALL_PATTERN = re.compile(
-    r"(sum|avg|count|max|min)\(\{([A-Za-z][A-Za-z0-9_.]*)\}\)"
-)
 
 
 def _substitute_aggregates(formula: str, data: dict[str, Any]) -> str:
@@ -137,7 +146,8 @@ def evaluate_formula(formula: str, data: dict[str, Any]) -> float | None:
     return _safe_eval(expr)
 
 
-def validate_formula(formula: str) -> list[str]:
+def validate_formula_syntax(formula: str) -> list[str]:
+    """キーベースに変換済みの計算式の構文を検証する。"""
     errors: list[str] = []
     if not formula or not formula.strip():
         errors.append("計算式が空です")
@@ -158,6 +168,89 @@ def validate_formula(formula: str) -> list[str]:
             return errors
 
     return errors
+
+
+def formula_labels_to_keys(
+    formula: str,
+    sibling_fields: list[dict[str, Any]],
+) -> tuple[str, list[str]]:
+    """ユーザーが入力したラベルベースの計算式をキーベースに変換する。
+
+    例: ``{単価} * {数量}`` → ``{price} * {qty}``
+    """
+    if not formula or not formula.strip():
+        return formula, []
+
+    label_to_key: dict[str, str] = {}
+    key_set: set[str] = set()
+    for field in sibling_fields:
+        label = field.get("label", "").strip()
+        key = field.get("key", "")
+        if label:
+            label_to_key[label] = key
+        if key:
+            key_set.add(key)
+
+    errors: list[str] = []
+
+    def _replace_aggregate(match: re.Match) -> str:
+        func_name = match.group(1)
+        ref = match.group(2).strip()
+        if ref in key_set:
+            return f"{func_name}({{{ref}}})"
+        if ref in label_to_key:
+            return f"{func_name}({{{label_to_key[ref]}}})"
+        errors.append(f"計算式のフィールド「{ref}」が見つかりません")
+        return match.group(0)
+
+    result = DISPLAY_AGGREGATE_PATTERN.sub(_replace_aggregate, formula)
+
+    def _replace_ref(match: re.Match) -> str:
+        ref = match.group(1).strip()
+        if ref in key_set:
+            return f"{{{ref}}}"
+        if ref in label_to_key:
+            return f"{{{label_to_key[ref]}}}"
+        errors.append(f"計算式のフィールド「{ref}」が見つかりません")
+        return match.group(0)
+
+    result = DISPLAY_REF_PATTERN.sub(_replace_ref, result)
+    return result, errors
+
+
+def formula_keys_to_labels(
+    formula: str,
+    sibling_fields: list[dict[str, Any]],
+) -> str:
+    """キーベースの計算式をラベルベースに変換する（表示用）。
+
+    例: ``{price} * {qty}`` → ``{単価} * {数量}``
+    """
+    if not formula or not formula.strip():
+        return formula
+
+    key_to_label: dict[str, str] = {}
+    for field in sibling_fields:
+        key = field.get("key", "")
+        label = field.get("label", "").strip()
+        if key and label:
+            key_to_label[key] = label
+
+    def _replace_aggregate(match: re.Match) -> str:
+        func_name = match.group(1)
+        ref = match.group(2)
+        label = key_to_label.get(ref, ref)
+        return f"{func_name}({{{label}}})"
+
+    result = AGGREGATE_CALL_PATTERN.sub(_replace_aggregate, formula)
+
+    def _replace_ref(match: re.Match) -> str:
+        ref = match.group(1)
+        label = key_to_label.get(ref, ref)
+        return f"{{{label}}}"
+
+    result = FIELD_REF_PATTERN.sub(_replace_ref, result)
+    return result
 
 
 def check_all_refs_required(

--- a/src/schemaform/calculated.py
+++ b/src/schemaform/calculated.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import ast
+import re
+from typing import Any
+
+FIELD_REF_PATTERN = re.compile(r"\{([A-Za-z][A-Za-z0-9_.]*)\}")
+
+AGGREGATE_FUNCTIONS = {"sum", "avg", "count", "max", "min"}
+
+
+def extract_field_refs(formula: str) -> list[str]:
+    return FIELD_REF_PATTERN.findall(formula)
+
+
+def _resolve_value(data: dict[str, Any], dotted_key: str) -> Any:
+    parts = dotted_key.split(".")
+    current: Any = data
+    for part in parts:
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+def _collect_numeric_values(value: Any) -> list[float]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        result: list[float] = []
+        for item in value:
+            if isinstance(item, (int, float)) and not isinstance(item, bool):
+                result.append(float(item))
+            elif isinstance(item, dict):
+                for v in item.values():
+                    if isinstance(v, (int, float)) and not isinstance(v, bool):
+                        result.append(float(v))
+        return result
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return [float(value)]
+    return []
+
+
+def _apply_aggregate(func_name: str, values: list[float]) -> float | None:
+    if func_name == "count":
+        return float(len(values))
+    if not values:
+        return None
+    if func_name == "sum":
+        return sum(values)
+    if func_name == "avg":
+        return sum(values) / len(values)
+    if func_name == "max":
+        return max(values)
+    if func_name == "min":
+        return min(values)
+    return None
+
+
+AGGREGATE_CALL_PATTERN = re.compile(
+    r"(sum|avg|count|max|min)\(\{([A-Za-z][A-Za-z0-9_.]*)\}\)"
+)
+
+
+def _substitute_aggregates(formula: str, data: dict[str, Any]) -> str:
+    def _replace_aggregate(match: re.Match) -> str:
+        func_name = match.group(1)
+        field_ref = match.group(2)
+        value = _resolve_value(data, field_ref)
+        numeric_values = _collect_numeric_values(value)
+        result = _apply_aggregate(func_name, numeric_values)
+        if result is None:
+            return "0"
+        return repr(result)
+
+    return AGGREGATE_CALL_PATTERN.sub(_replace_aggregate, formula)
+
+
+def _substitute_field_refs(formula: str, data: dict[str, Any]) -> str:
+    def _replace_ref(match: re.Match) -> str:
+        field_ref = match.group(1)
+        value = _resolve_value(data, field_ref)
+        if value is None:
+            return "0"
+        if isinstance(value, bool):
+            return "0"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        return "0"
+
+    return FIELD_REF_PATTERN.sub(_replace_ref, formula)
+
+
+_ALLOWED_NODE_TYPES = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Constant,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.USub,
+    ast.UAdd,
+)
+
+
+def _safe_eval(expr: str) -> float | None:
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError:
+        return None
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODE_TYPES):
+            return None
+
+    try:
+        result = eval(compile(tree, "<formula>", "eval"))  # noqa: S307
+    except (ZeroDivisionError, TypeError, ValueError, OverflowError):
+        return None
+
+    if isinstance(result, (int, float)) and not isinstance(result, bool):
+        return float(result)
+    return None
+
+
+def evaluate_formula(formula: str, data: dict[str, Any]) -> float | None:
+    if not formula or not formula.strip():
+        return None
+    expr = _substitute_aggregates(formula, data)
+    expr = _substitute_field_refs(expr, data)
+    return _safe_eval(expr)
+
+
+def validate_formula(formula: str) -> list[str]:
+    errors: list[str] = []
+    if not formula or not formula.strip():
+        errors.append("計算式が空です")
+        return errors
+
+    test_expr = AGGREGATE_CALL_PATTERN.sub("0", formula)
+    test_expr = FIELD_REF_PATTERN.sub("0", test_expr)
+
+    try:
+        tree = ast.parse(test_expr, mode="eval")
+    except SyntaxError:
+        errors.append("計算式の構文が不正です")
+        return errors
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODE_TYPES):
+            errors.append("計算式に許可されていない要素が含まれています")
+            return errors
+
+    return errors
+
+
+def check_all_refs_required(
+    formula: str,
+    field_map: dict[str, dict[str, Any]],
+) -> bool:
+    refs = extract_field_refs(formula)
+    if not refs:
+        return False
+    for ref in refs:
+        root_key = ref.split(".")[0]
+        field = field_map.get(root_key)
+        if not field or not field.get("required"):
+            return False
+    return True

--- a/src/schemaform/calculated.py
+++ b/src/schemaform/calculated.py
@@ -30,9 +30,23 @@ def extract_field_refs(formula: str) -> list[str]:
 def _resolve_value(data: dict[str, Any], dotted_key: str) -> Any:
     parts = dotted_key.split(".")
     current: Any = data
-    for part in parts:
+    for i, part in enumerate(parts):
         if isinstance(current, dict):
             current = current.get(part)
+        elif isinstance(current, list):
+            remaining = parts[i:]
+            results: list[Any] = []
+            for item in current:
+                sub: Any = item
+                for sub_part in remaining:
+                    if isinstance(sub, dict):
+                        sub = sub.get(sub_part)
+                    else:
+                        sub = None
+                        break
+                if sub is not None:
+                    results.append(sub)
+            return results if results else None
         else:
             return None
     return current
@@ -190,6 +204,14 @@ def formula_labels_to_keys(
             label_to_key[label] = key
         if key:
             key_set.add(key)
+        if field.get("type") == "group" and field.get("children"):
+            for child in field["children"]:
+                child_label = child.get("label", "").strip()
+                child_key = child.get("key", "")
+                if label and child_label:
+                    label_to_key[f"{label}.{child_label}"] = f"{key}.{child_key}"
+                if key and child_key:
+                    key_set.add(f"{key}.{child_key}")
 
     errors: list[str] = []
 
@@ -235,6 +257,12 @@ def formula_keys_to_labels(
         label = field.get("label", "").strip()
         if key and label:
             key_to_label[key] = label
+        if field.get("type") == "group" and field.get("children"):
+            for child in field["children"]:
+                child_key = child.get("key", "")
+                child_label = child.get("label", "").strip()
+                if key and child_key and label and child_label:
+                    key_to_label[f"{key}.{child_key}"] = f"{label}.{child_label}"
 
     def _replace_aggregate(match: re.Match) -> str:
         func_name = match.group(1)

--- a/src/schemaform/config.py
+++ b/src/schemaform/config.py
@@ -16,6 +16,7 @@ ALLOWED_TYPES = {
     "time",
     "group",
     "master",
+    "calculated",
 }
 KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 

--- a/src/schemaform/routes/api.py
+++ b/src/schemaform/routes/api.py
@@ -5,6 +5,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from schemaform.calculated import evaluate_formula
 from schemaform.filters import (
     apply_filters,
     collect_file_ids,
@@ -132,9 +133,26 @@ async def api_submit_form(public_id: str, request: Request) -> JSONResponse:
     if not isinstance(data, dict):
         raise HTTPException(status_code=400, detail="data_jsonが不正です")
 
+    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
+
+    def _compute_calculated_api(
+        field_list: list[Any], target: dict[str, Any],
+    ) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                result = evaluate_formula(field["formula"], target)
+                if result is not None:
+                    target[field["key"]] = result
+            elif field["type"] == "group" and not field.get("is_array"):
+                children = field.get("children") or []
+                group_data = target.get(field["key"])
+                if isinstance(group_data, dict):
+                    _compute_calculated_api(children, group_data)
+
+    _compute_calculated_api(fields, data)
+
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(data), key=lambda err: list(err.path))
-    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
     master_errors = validate_master_references(storage, fields, data)
     if errors or master_errors:
         raise HTTPException(status_code=400, detail="バリデーションに失敗しました")

--- a/src/schemaform/routes/api.py
+++ b/src/schemaform/routes/api.py
@@ -26,22 +26,6 @@ from schemaform.webhook import is_valid_webhook_url
 router = APIRouter()
 
 
-def _recompute_calculated_api(
-    field_list: list[Any], data: dict[str, Any],
-) -> None:
-    """保存済みデータに対して計算フィールドの値を再計算する。"""
-    for field in field_list:
-        if field["type"] == "calculated" and field.get("formula"):
-            result = evaluate_formula(field["formula"], data)
-            if result is not None:
-                data[field["key"]] = result
-        elif field["type"] == "group" and not field.get("is_array"):
-            children = field.get("children") or []
-            group_data = data.get(field["key"])
-            if isinstance(group_data, dict):
-                _recompute_calculated_api(children, group_data)
-
-
 @router.get("/api/forms", tags=["api/forms"])
 async def api_list_forms(request: Request) -> JSONResponse:
     storage = request.app.state.storage
@@ -228,19 +212,16 @@ async def api_list_submissions(request: Request, form_id: str) -> JSONResponse:
             raise HTTPException(status_code=400, detail="cursorが不正です")
 
     page_items = filtered[:limit]
-    response_items = []
-    for item in page_items:
-        data = item.get("data_json", {})
-        _recompute_calculated_api(fields, data)
-        response_items.append(
-            {
-                "id": item["id"],
-                "form_id": item["form_id"],
-                "data_json": data,
-                "created_at": to_iso(item["created_at"]),
-                "updated_at": to_iso(item["updated_at"]) if item.get("updated_at") else None,
-            }
-        )
+    response_items = [
+        {
+            "id": item["id"],
+            "form_id": item["form_id"],
+            "data_json": item.get("data_json", {}),
+            "created_at": to_iso(item["created_at"]),
+            "updated_at": to_iso(item["updated_at"]) if item.get("updated_at") else None,
+        }
+        for item in page_items
+    ]
     headers: dict[str, str] = {}
     if len(page_items) == limit:
         last = page_items[-1]

--- a/src/schemaform/routes/api.py
+++ b/src/schemaform/routes/api.py
@@ -26,6 +26,22 @@ from schemaform.webhook import is_valid_webhook_url
 router = APIRouter()
 
 
+def _recompute_calculated_api(
+    field_list: list[Any], data: dict[str, Any],
+) -> None:
+    """保存済みデータに対して計算フィールドの値を再計算する。"""
+    for field in field_list:
+        if field["type"] == "calculated" and field.get("formula"):
+            result = evaluate_formula(field["formula"], data)
+            if result is not None:
+                data[field["key"]] = result
+        elif field["type"] == "group" and not field.get("is_array"):
+            children = field.get("children") or []
+            group_data = data.get(field["key"])
+            if isinstance(group_data, dict):
+                _recompute_calculated_api(children, group_data)
+
+
 @router.get("/api/forms", tags=["api/forms"])
 async def api_list_forms(request: Request) -> JSONResponse:
     storage = request.app.state.storage
@@ -212,16 +228,19 @@ async def api_list_submissions(request: Request, form_id: str) -> JSONResponse:
             raise HTTPException(status_code=400, detail="cursorが不正です")
 
     page_items = filtered[:limit]
-    response_items = [
-        {
-            "id": item["id"],
-            "form_id": item["form_id"],
-            "data_json": item.get("data_json", {}),
-            "created_at": to_iso(item["created_at"]),
-            "updated_at": to_iso(item["updated_at"]) if item.get("updated_at") else None,
-        }
-        for item in page_items
-    ]
+    response_items = []
+    for item in page_items:
+        data = item.get("data_json", {})
+        _recompute_calculated_api(fields, data)
+        response_items.append(
+            {
+                "id": item["id"],
+                "form_id": item["form_id"],
+                "data_json": data,
+                "created_at": to_iso(item["created_at"]),
+                "updated_at": to_iso(item["updated_at"]) if item.get("updated_at") else None,
+            }
+        )
     headers: dict[str, str] = {}
     if len(page_items) == limit:
         last = page_items[-1]

--- a/src/schemaform/routes/public.py
+++ b/src/schemaform/routes/public.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from jsonschema import Draft7Validator
 
+from schemaform.calculated import evaluate_formula
 from schemaform.file_formats import upload_matches_file_constraints
 from schemaform.fields import clean_empty_recursive
 from schemaform.filters import normalize_number, parse_bool
@@ -200,6 +201,22 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
 
     await collect_fields(fields, submission, "")
     submission = clean_empty_recursive(submission) or {}
+
+    def _compute_calculated(
+        field_list: list[dict[str, Any]], data: dict[str, Any],
+    ) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                result = evaluate_formula(field["formula"], data)
+                if result is not None:
+                    data[field["key"]] = result
+            elif field["type"] == "group" and not field.get("is_array"):
+                children = field.get("children") or []
+                group_data = data.get(field["key"])
+                if isinstance(group_data, dict):
+                    _compute_calculated(children, group_data)
+
+    _compute_calculated(fields, submission)
 
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(submission), key=lambda err: list(err.path))

--- a/src/schemaform/routes/public.py
+++ b/src/schemaform/routes/public.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from jsonschema import Draft7Validator
 
-from schemaform.calculated import evaluate_formula
 from schemaform.file_formats import upload_matches_file_constraints
 from schemaform.fields import clean_empty_recursive
 from schemaform.filters import normalize_number, parse_bool
@@ -118,6 +117,8 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
             is_array = field.get("is_array", False)
 
             if field_type == "calculated":
+                raw_value = form_data.get(form_key)
+                target[key] = normalize_number(raw_value, False)
                 continue
 
             if field_type == "group":
@@ -199,22 +200,6 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
 
     await collect_fields(fields, submission, "")
     submission = clean_empty_recursive(submission) or {}
-
-    def _compute_calculated(
-        field_list: list[dict[str, Any]], data: dict[str, Any],
-    ) -> None:
-        for field in field_list:
-            if field["type"] == "calculated" and field.get("formula"):
-                result = evaluate_formula(field["formula"], data)
-                if result is not None:
-                    data[field["key"]] = result
-            elif field["type"] == "group" and not field.get("is_array"):
-                children = field.get("children") or []
-                group_data = data.get(field["key"])
-                if isinstance(group_data, dict):
-                    _compute_calculated(children, group_data)
-
-    _compute_calculated(fields, submission)
 
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(submission), key=lambda err: list(err.path))

--- a/src/schemaform/routes/public.py
+++ b/src/schemaform/routes/public.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from jsonschema import Draft7Validator
 
+from schemaform.calculated import evaluate_formula
 from schemaform.file_formats import upload_matches_file_constraints
 from schemaform.fields import clean_empty_recursive
 from schemaform.filters import normalize_number, parse_bool
@@ -116,6 +117,9 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
             field_type = field["type"]
             is_array = field.get("is_array", False)
 
+            if field_type == "calculated":
+                continue
+
             if field_type == "group":
                 children = field.get("children") or []
                 if is_array:
@@ -195,6 +199,22 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
 
     await collect_fields(fields, submission, "")
     submission = clean_empty_recursive(submission) or {}
+
+    def _compute_calculated(
+        field_list: list[dict[str, Any]], data: dict[str, Any],
+    ) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                result = evaluate_formula(field["formula"], data)
+                if result is not None:
+                    data[field["key"]] = result
+            elif field["type"] == "group" and not field.get("is_array"):
+                children = field.get("children") or []
+                group_data = data.get(field["key"])
+                if isinstance(group_data, dict):
+                    _compute_calculated(children, group_data)
+
+    _compute_calculated(fields, submission)
 
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(submission), key=lambda err: list(err.path))

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -8,7 +8,6 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
 
-from schemaform.calculated import evaluate_formula
 from schemaform.fields import (
     clean_empty_recursive,
     expand_group_array_rows,
@@ -201,22 +200,6 @@ def sort_submissions(
     submissions.sort(key=lambda s: str(s.get("created_at") or ""), reverse=True)
 
 
-def _recompute_calculated(
-    field_list: list[dict[str, Any]], data: dict[str, Any],
-) -> None:
-    """保存済みデータに対して計算フィールドの値を再計算する。"""
-    for field in field_list:
-        if field["type"] == "calculated" and field.get("formula"):
-            result = evaluate_formula(field["formula"], data)
-            if result is not None:
-                data[field["key"]] = result
-        elif field["type"] == "group" and not field.get("is_array"):
-            children = field.get("children") or []
-            group_data = data.get(field["key"])
-            if isinstance(group_data, dict):
-                _recompute_calculated(children, group_data)
-
-
 def build_submission_row_values(
     data: dict[str, Any],
     display_columns: list[dict[str, Any]],
@@ -305,7 +288,6 @@ async def list_submissions(
     display_rows = []
     for item in page_items:
         data = item.get("data_json", {})
-        _recompute_calculated(fields, data)
         row_values = build_submission_row_values(
             data,
             display_columns,
@@ -439,6 +421,8 @@ async def update_submission(
             is_array = field.get("is_array", False)
 
             if field_type == "calculated":
+                raw_value = form_data.get(form_key)
+                target[key] = normalize_number(raw_value, False)
                 continue
 
             if field_type == "group":
@@ -531,22 +515,6 @@ async def update_submission(
     await collect_fields(fields, submission, "", old_data)
     submission = clean_empty_recursive(submission) or {}
 
-    def _compute_calculated_edit(
-        field_list: list[dict[str, Any]], data: dict[str, Any],
-    ) -> None:
-        for field in field_list:
-            if field["type"] == "calculated" and field.get("formula"):
-                result = evaluate_formula(field["formula"], data)
-                if result is not None:
-                    data[field["key"]] = result
-            elif field["type"] == "group" and not field.get("is_array"):
-                children = field.get("children") or []
-                group_data = data.get(field["key"])
-                if isinstance(group_data, dict):
-                    _compute_calculated_edit(children, group_data)
-
-    _compute_calculated_edit(fields, submission)
-
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(submission), key=lambda err: list(err.path))
     master_errors = validate_master_references(storage, fields, submission)
@@ -614,11 +582,9 @@ async def export_submissions(
     headers = [column["label"] for column in display_columns]
     rows = []
     for submission in filtered:
-        data = submission.get("data_json", {})
-        _recompute_calculated(fields, data)
         rows.append(
             build_submission_row_values(
-                data,
+                submission.get("data_json", {}),
                 display_columns,
                 master_lookup_by_field,
                 file_names,

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -201,6 +201,22 @@ def sort_submissions(
     submissions.sort(key=lambda s: str(s.get("created_at") or ""), reverse=True)
 
 
+def _recompute_calculated(
+    field_list: list[dict[str, Any]], data: dict[str, Any],
+) -> None:
+    """保存済みデータに対して計算フィールドの値を再計算する。"""
+    for field in field_list:
+        if field["type"] == "calculated" and field.get("formula"):
+            result = evaluate_formula(field["formula"], data)
+            if result is not None:
+                data[field["key"]] = result
+        elif field["type"] == "group" and not field.get("is_array"):
+            children = field.get("children") or []
+            group_data = data.get(field["key"])
+            if isinstance(group_data, dict):
+                _recompute_calculated(children, group_data)
+
+
 def build_submission_row_values(
     data: dict[str, Any],
     display_columns: list[dict[str, Any]],
@@ -289,6 +305,7 @@ async def list_submissions(
     display_rows = []
     for item in page_items:
         data = item.get("data_json", {})
+        _recompute_calculated(fields, data)
         row_values = build_submission_row_values(
             data,
             display_columns,
@@ -595,15 +612,18 @@ async def export_submissions(
     sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
 
     headers = [column["label"] for column in display_columns]
-    rows = [
-        build_submission_row_values(
-            submission.get("data_json", {}),
-            display_columns,
-            master_lookup_by_field,
-            file_names,
+    rows = []
+    for submission in filtered:
+        data = submission.get("data_json", {})
+        _recompute_calculated(fields, data)
+        rows.append(
+            build_submission_row_values(
+                data,
+                display_columns,
+                master_lookup_by_field,
+                file_names,
+            )
         )
-        for submission in filtered
-    ]
 
     fmt = request.query_params.get("format", "csv")
     delimiter = "," if fmt == "csv" else "\t"

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
 
+from schemaform.calculated import evaluate_formula
 from schemaform.fields import (
     clean_empty_recursive,
     expand_group_array_rows,
@@ -515,6 +516,22 @@ async def update_submission(
     await collect_fields(fields, submission, "", old_data)
     submission = clean_empty_recursive(submission) or {}
 
+    def _compute_calculated_edit(
+        field_list: list[dict[str, Any]], data: dict[str, Any],
+    ) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                result = evaluate_formula(field["formula"], data)
+                if result is not None:
+                    data[field["key"]] = result
+            elif field["type"] == "group" and not field.get("is_array"):
+                children = field.get("children") or []
+                group_data = data.get(field["key"])
+                if isinstance(group_data, dict):
+                    _compute_calculated_edit(children, group_data)
+
+    _compute_calculated_edit(fields, submission)
+
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(submission), key=lambda err: list(err.path))
     master_errors = validate_master_references(storage, fields, submission)
@@ -580,16 +597,15 @@ async def export_submissions(
     sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
 
     headers = [column["label"] for column in display_columns]
-    rows = []
-    for submission in filtered:
-        rows.append(
-            build_submission_row_values(
-                submission.get("data_json", {}),
-                display_columns,
-                master_lookup_by_field,
-                file_names,
-            )
+    rows = [
+        build_submission_row_values(
+            submission.get("data_json", {}),
+            display_columns,
+            master_lookup_by_field,
+            file_names,
         )
+        for submission in filtered
+    ]
 
     fmt = request.query_params.get("format", "csv")
     delimiter = "," if fmt == "csv" else "\t"

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
 
+from schemaform.calculated import evaluate_formula
 from schemaform.fields import (
     clean_empty_recursive,
     expand_group_array_rows,
@@ -420,6 +421,9 @@ async def update_submission(
             field_type = field["type"]
             is_array = field.get("is_array", False)
 
+            if field_type == "calculated":
+                continue
+
             if field_type == "group":
                 children = field.get("children") or []
                 if is_array:
@@ -509,6 +513,22 @@ async def update_submission(
 
     await collect_fields(fields, submission, "", old_data)
     submission = clean_empty_recursive(submission) or {}
+
+    def _compute_calculated_edit(
+        field_list: list[dict[str, Any]], data: dict[str, Any],
+    ) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                result = evaluate_formula(field["formula"], data)
+                if result is not None:
+                    data[field["key"]] = result
+            elif field["type"] == "group" and not field.get("is_array"):
+                children = field.get("children") or []
+                group_data = data.get(field["key"])
+                if isinstance(group_data, dict):
+                    _compute_calculated_edit(children, group_data)
+
+    _compute_calculated_edit(fields, submission)
 
     validator = Draft7Validator(form["schema_json"])
     errors = sorted(validator.iter_errors(submission), key=lambda err: list(err.path))

--- a/src/schemaform/schema.py
+++ b/src/schemaform/schema.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import orjson
 
-from schemaform.calculated import validate_formula
+from schemaform.calculated import (
+    formula_keys_to_labels,
+    formula_labels_to_keys,
+    validate_formula_syntax,
+)
 from schemaform.config import ALLOWED_TYPES, KEY_PATTERN
 from schemaform.file_formats import (
     normalize_allowed_extensions,
@@ -84,10 +88,6 @@ def parse_fields_json(fields_json: str) -> tuple[list[dict[str, Any]], list[str]
                 formula = str(raw.get("formula", "")).strip()
                 if not formula:
                     errors.append(f"{loc}: 計算式を指定してください")
-                else:
-                    formula_errors = validate_formula(formula)
-                    for fe in formula_errors:
-                        errors.append(f"{loc}: {fe}")
 
             if field_type not in ALLOWED_TYPES:
                 errors.append(f"{loc}: 種類が不正です ({field_type})")
@@ -147,6 +147,22 @@ def parse_fields_json(fields_json: str) -> tuple[list[dict[str, Any]], list[str]
 
     if not fields:
         errors.append("最低1つのフィールドが必要です")
+
+    def _resolve_formulas(field_list: list[dict[str, Any]]) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                converted, conv_errors = formula_labels_to_keys(
+                    field["formula"], field_list,
+                )
+                errors.extend(conv_errors)
+                field["formula"] = converted
+                syntax_errors = validate_formula_syntax(converted)
+                for se in syntax_errors:
+                    errors.append(se)
+            if field["type"] == "group" and field.get("children"):
+                _resolve_formulas(field["children"])
+
+    _resolve_formulas(fields)
 
     return fields, errors
 
@@ -380,4 +396,16 @@ def fields_from_schema(schema: dict[str, Any], field_order: list[str]) -> list[d
                 "children": [],
             }
         )
+
+    def _display_formulas(field_list: list[dict[str, Any]]) -> None:
+        for field in field_list:
+            if field["type"] == "calculated" and field.get("formula"):
+                field["formula"] = formula_keys_to_labels(
+                    field["formula"], field_list,
+                )
+            if field["type"] == "group" and field.get("children"):
+                _display_formulas(field["children"])
+
+    _display_formulas(fields)
+
     return fields

--- a/src/schemaform/schema.py
+++ b/src/schemaform/schema.py
@@ -400,6 +400,7 @@ def fields_from_schema(schema: dict[str, Any], field_order: list[str]) -> list[d
     def _display_formulas(field_list: list[dict[str, Any]]) -> None:
         for field in field_list:
             if field["type"] == "calculated" and field.get("formula"):
+                field["formula_raw"] = field["formula"]
                 field["formula"] = formula_keys_to_labels(
                     field["formula"], field_list,
                 )

--- a/src/schemaform/schema.py
+++ b/src/schemaform/schema.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import orjson
 
+from schemaform.calculated import validate_formula
 from schemaform.config import ALLOWED_TYPES, KEY_PATTERN
 from schemaform.file_formats import (
     normalize_allowed_extensions,
@@ -78,6 +79,16 @@ def parse_fields_json(fields_json: str) -> tuple[list[dict[str, Any]], list[str]
                         seen_display_keys.add(key_name)
                         master_display_fields.append(key_name)
 
+            formula = ""
+            if field_type == "calculated":
+                formula = str(raw.get("formula", "")).strip()
+                if not formula:
+                    errors.append(f"{loc}: 計算式を指定してください")
+                else:
+                    formula_errors = validate_formula(formula)
+                    for fe in formula_errors:
+                        errors.append(f"{loc}: {fe}")
+
             if field_type not in ALLOWED_TYPES:
                 errors.append(f"{loc}: 種類が不正です ({field_type})")
             if field_type == "master" and not master_form_id:
@@ -126,6 +137,7 @@ def parse_fields_json(fields_json: str) -> tuple[list[dict[str, Any]], list[str]
                     "master_form_id": master_form_id,
                     "master_label_key": master_label_key,
                     "master_display_fields": master_display_fields,
+                    "formula": formula,
                     "children": children,
                 }
             )
@@ -177,7 +189,14 @@ def build_property(field: dict[str, Any]) -> dict[str, Any]:
             payload["format"] = field["format"]
         return payload
 
-    if field["type"] == "group":
+    if field["type"] == "calculated":
+        prop: dict[str, Any] = {
+            "type": "number",
+            "x-field-type": "calculated",
+        }
+        if field.get("formula"):
+            prop["x-formula"] = field["formula"]
+    elif field["type"] == "group":
         children = field.get("children") or []
         child_schema, child_order = schema_from_fields(children)
         obj: dict[str, Any] = {
@@ -305,6 +324,7 @@ def fields_from_schema(schema: dict[str, Any], field_order: list[str]) -> list[d
                     "master_form_id": "",
                     "master_label_key": "",
                     "master_display_fields": [],
+                    "formula": "",
                     "children": children,
                 }
             )
@@ -323,6 +343,8 @@ def fields_from_schema(schema: dict[str, Any], field_order: list[str]) -> list[d
             field_type = "file"
         if target.get("x-field-type") == "master":
             field_type = "master"
+        if target.get("x-field-type") == "calculated":
+            field_type = "calculated"
 
         fields.append(
             {
@@ -354,6 +376,7 @@ def fields_from_schema(schema: dict[str, Any], field_order: list[str]) -> list[d
                 "master_form_id": target.get("x-master-form-id", "") if field_type == "master" else "",
                 "master_label_key": target.get("x-master-label-key", "") if field_type == "master" else "",
                 "master_display_fields": master_display_fields if field_type == "master" else [],
+                "formula": target.get("x-formula", "") if field_type == "calculated" else "",
                 "children": [],
             }
         )

--- a/src/schemaform/schema.py
+++ b/src/schemaform/schema.py
@@ -288,7 +288,7 @@ def schema_from_fields(fields: list[dict[str, Any]]) -> tuple[dict[str, Any], li
         key = field["key"]
         field_order.append(key)
         properties[key] = build_property(field)
-        if field.get("required"):
+        if field.get("required") and field.get("type") != "calculated":
             required.append(key)
     schema: dict[str, Any] = {"type": "object", "properties": properties}
     if required:

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -195,6 +195,14 @@
       <p class="mt-1 text-xs text-slate-500">表示は参照元の送信内容から自動生成されます。</p>
     </div>
 
+    <div data-role="calculated-config" class="mt-3 hidden">
+      <div>
+        <label class="text-xs text-slate-500">計算式</label>
+        <input data-field="formula" class="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm font-mono" placeholder="{price} * {quantity}" />
+        <p class="mt-1 text-xs text-slate-500">フィールドのキーを <code>{キー名}</code> で参照。配列には <code>sum({キー})</code> <code>avg({キー})</code> <code>count({キー})</code> <code>max({キー})</code> <code>min({キー})</code> が使えます。</p>
+      </div>
+    </div>
+
     <div data-role="group-children" class="mt-3 hidden">
       <div>
         <div class="text-xs font-semibold text-slate-500">子フィールド</div>
@@ -260,6 +268,7 @@
       <button type="button" class="type-option rounded border border-slate-300 px-3 py-2 text-sm" data-type="master">フォーム参照</button>
       <button type="button" class="type-option rounded border border-slate-300 px-3 py-2 text-sm" data-type="file">ファイル</button>
       <button type="button" class="type-option rounded border border-slate-300 px-3 py-2 text-sm" data-type="group">グループ</button>
+      <button type="button" class="type-option rounded border border-slate-300 px-3 py-2 text-sm" data-type="calculated">計算</button>
     </div>
     <div class="mt-4 flex justify-end">
       <button type="button" id="close-type-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">キャンセル</button>
@@ -293,6 +302,7 @@
     master: "フォーム参照",
     file: "ファイル",
     group: "グループ",
+    calculated: "計算",
   };
   const stringFormatOptions = [
     { value: "", label: "指定なし" },
@@ -326,6 +336,7 @@
     master_form_id: "",
     master_label_key: "",
     master_display_fields: [],
+    formula: "",
     children: [],
   };
 
@@ -363,6 +374,9 @@
     }
     if (!Array.isArray(field.allowed_extensions)) {
       field.allowed_extensions = [];
+    }
+    if (typeof field.formula !== "string") {
+      field.formula = "";
     }
     return field;
   }
@@ -622,6 +636,7 @@
     const type = row.querySelector('[data-field="type"]').value;
     const isArray = row.querySelector('[data-field="is_array"]').checked;
     const isGroup = type === "group";
+    const isCalculated = type === "calculated";
     const showEnum = type === "enum";
     const showMasterConfig = type === "master";
     const showMinMax = type === "number" || type === "integer";
@@ -632,16 +647,24 @@
     const showExpandRows = isGroup && isArray;
     row.querySelector('[data-role="enum"]').classList.toggle("hidden", !showEnum);
     row.querySelector('[data-role="master-config"]').classList.toggle("hidden", !showMasterConfig);
+    row.querySelector('[data-role="calculated-config"]').classList.toggle("hidden", !isCalculated);
     row.querySelector('[data-role="minmax"]').classList.toggle("hidden", !showMinMax);
-    row.querySelector('[data-role="format"]').classList.toggle("hidden", isGroup || !showFormat);
-    row.querySelector('[data-role="placeholder"]').classList.toggle("hidden", isGroup || !showPlaceholder);
+    row.querySelector('[data-role="format"]').classList.toggle("hidden", isGroup || isCalculated || !showFormat);
+    row.querySelector('[data-role="placeholder"]').classList.toggle("hidden", isGroup || isCalculated || !showPlaceholder);
     row.querySelector('[data-role="file-extensions"]').classList.toggle("hidden", !showFileExtensions);
-    row.querySelector('[data-role="multiline"]').classList.toggle("hidden", isGroup || !showMultiline);
+    row.querySelector('[data-role="multiline"]').classList.toggle("hidden", isGroup || isCalculated || !showMultiline);
     row.querySelector('[data-role="expand-rows"]').classList.toggle("hidden", !showExpandRows);
     row.querySelector('[data-role="group-children"]').classList.toggle("hidden", !isGroup);
 
     if (!showExpandRows) {
       row.querySelector('[data-field="expand_rows"]').checked = false;
+    }
+
+    if (isCalculated) {
+      row.querySelector('[data-field="is_array"]').checked = false;
+      row.querySelector('[data-field="is_array"]').closest("label").classList.add("hidden");
+    } else {
+      row.querySelector('[data-field="is_array"]').closest("label").classList.remove("hidden");
     }
 
     if (!isGroup) {
@@ -704,6 +727,7 @@
       master_display_fields: type === "master"
         ? Array.from(row.querySelectorAll('[data-field="master_display_field"]:checked')).map((el) => el.value)
         : [],
+      formula: type === "calculated" ? get("formula").value.trim() : "",
       children: [],
     };
 
@@ -792,6 +816,7 @@
     setValue(row, "is_array", normalized.is_array);
     setValue(row, "expand_rows", normalized.expand_rows);
     setValue(row, "multiline", normalized.multiline);
+    setValue(row, "formula", normalized.formula || "");
     initMasterConfig(
       row,
       normalized.master_form_id,

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -198,8 +198,9 @@
     <div data-role="calculated-config" class="mt-3 hidden">
       <div>
         <label class="text-xs text-slate-500">計算式</label>
-        <input data-field="formula" class="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm font-mono" placeholder="{price} * {quantity}" />
-        <p class="mt-1 text-xs text-slate-500">フィールドのキーを <code>{キー名}</code> で参照。配列には <code>sum({キー})</code> <code>avg({キー})</code> <code>count({キー})</code> <code>max({キー})</code> <code>min({キー})</code> が使えます。</p>
+        <input data-field="formula" class="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm font-mono" placeholder="{単価} * {数量}" />
+        <p class="mt-1 text-xs text-slate-500">フィールド名をクリックして挿入。配列には <code>sum()</code> <code>avg()</code> <code>count()</code> <code>max()</code> <code>min()</code> が使えます。</p>
+        <div data-role="formula-fields" class="mt-2 flex flex-wrap gap-1.5"></div>
       </div>
     </div>
 
@@ -632,6 +633,83 @@
     refreshMasterDisplayFieldOptions(row, selectedDisplayFields || []);
   }
 
+  function refreshFormulaFields(row) {
+    const container = row.querySelector('[data-role="formula-fields"]');
+    if (!container) return;
+    const type = row.querySelector('[data-field="type"]').value;
+    if (type !== "calculated") {
+      container.replaceChildren();
+      return;
+    }
+    const formulaInput = row.querySelector('[data-field="formula"]');
+    if (!formulaInput) return;
+
+    // 同階層のフィールド一覧を取得（自分自身を除く）
+    const parentContainer = row.parentElement;
+    if (!parentContainer) return;
+    const siblingRows = Array.from(parentContainer.querySelectorAll(":scope > .field-row"));
+    const myKey = row.querySelector('[data-field="key"]').value;
+
+    container.replaceChildren();
+    const numericTypes = new Set(["number", "integer", "calculated"]);
+    const arrayTypes = new Set(["number", "integer"]);
+
+    siblingRows.forEach((siblingRow) => {
+      const siblingKey = siblingRow.querySelector('[data-field="key"]').value;
+      if (siblingKey === myKey) return;
+      const siblingType = siblingRow.querySelector('[data-field="type"]').value;
+      const siblingLabel = siblingRow.querySelector('[data-field="label"]').value.trim();
+      const siblingIsArray = siblingRow.querySelector('[data-field="is_array"]').checked;
+      const displayName = siblingLabel || siblingKey;
+
+      if (numericTypes.has(siblingType) && !siblingIsArray) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "rounded border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs text-sky-700 hover:bg-sky-100";
+        btn.textContent = displayName;
+        btn.title = `{${displayName}} を挿入`;
+        btn.addEventListener("click", () => {
+          insertAtCursor(formulaInput, `{${displayName}}`);
+          updateFieldsJson();
+        });
+        container.appendChild(btn);
+      }
+
+      if (siblingIsArray && arrayTypes.has(siblingType)) {
+        ["sum", "avg", "count", "max", "min"].forEach((fn) => {
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.className = "rounded border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700 hover:bg-emerald-100";
+          btn.textContent = `${fn}(${displayName})`;
+          btn.title = `${fn}({${displayName}}) を挿入`;
+          btn.addEventListener("click", () => {
+            insertAtCursor(formulaInput, `${fn}({${displayName}})`);
+            updateFieldsJson();
+          });
+          container.appendChild(btn);
+        });
+      }
+    });
+
+    if (container.children.length === 0) {
+      const empty = document.createElement("span");
+      empty.className = "text-xs text-slate-400";
+      empty.textContent = "参照可能な数値フィールドがありません";
+      container.appendChild(empty);
+    }
+  }
+
+  function insertAtCursor(input, text) {
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? start;
+    const before = input.value.substring(0, start);
+    const after = input.value.substring(end);
+    input.value = before + text + after;
+    const newPos = start + text.length;
+    input.setSelectionRange(newPos, newPos);
+    input.focus();
+  }
+
   function applyVisibility(row) {
     const type = row.querySelector('[data-field="type"]').value;
     const isArray = row.querySelector('[data-field="is_array"]').checked;
@@ -672,6 +750,7 @@
     }
     refreshFormatOptions(row);
     syncFileExtensionPriority(row);
+    refreshFormulaFields(row);
     if (showMasterConfig) {
       refreshMasterLabelOptions(row);
       refreshMasterDisplayFieldOptions(
@@ -751,6 +830,13 @@
     refreshRowDepthStyles();
     const fields = readFieldsFromContainer(fieldList);
     fieldsInput.value = JSON.stringify(fields);
+    // 全ての計算フィールドの参照ボタンを更新
+    document.querySelectorAll('.field-row').forEach((row) => {
+      const typeInput = row.querySelector('[data-field="type"]');
+      if (typeInput && typeInput.value === "calculated") {
+        refreshFormulaFields(row);
+      }
+    });
   }
 
   function initSortable(container) {

--- a/templates/form_public.html
+++ b/templates/form_public.html
@@ -92,6 +92,26 @@
   </div>
   {% endif %}
 
+{% elif field.type == "calculated" %}
+  {# 計算フィールド #}
+  <div class="py-2 lg:py-3">
+    <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">
+      <div class="lg:col-span-3">
+        <label class="block text-sm font-semibold leading-6">
+          {{ field.label or field.key }}
+        </label>
+        {% if field.description %}
+        <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">{{ field.description }}</div>
+        {% endif %}
+      </div>
+      <div class="sf-field-input-col lg:col-span-9">
+        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula | e }}" data-key="{{ form_name }}">
+          <span class="text-slate-400">自動計算</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
 {% else %}
   {# 通常フィールド（非グループ） #}
   {% set ns = namespace(fw="max-w-md") %}

--- a/templates/form_public.html
+++ b/templates/form_public.html
@@ -105,7 +105,7 @@
         {% endif %}
       </div>
       <div class="sf-field-input-col lg:col-span-9">
-        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula | e }}" data-key="{{ form_name }}">
+        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula_raw | e }}" data-key="{{ form_name }}">
           <span class="text-slate-400">自動計算</span>
         </div>
       </div>

--- a/templates/form_public.html
+++ b/templates/form_public.html
@@ -108,6 +108,7 @@
         <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula_raw | e }}" data-key="{{ form_name }}">
           <span class="text-slate-400">自動計算</span>
         </div>
+        <input type="hidden" name="{{ form_name }}" data-role="calculated-value" value="">
       </div>
     </div>
   </div>
@@ -1053,14 +1054,17 @@
       const formula = el.dataset.formula;
       if (!formula) return;
       const result = evaluateFormulaClient(formula, data);
+      const hiddenInput = el.parentElement.querySelector("[data-role='calculated-value']");
       if (result !== null) {
         const formatted = Number.isInteger(result) ? String(result) : result.toFixed(10).replace(/\.?0+$/, "");
         el.textContent = formatted;
         el.classList.remove("text-slate-400");
         el.classList.add("text-slate-700", "font-medium");
+        if (hiddenInput) hiddenInput.value = result;
       } else {
         el.innerHTML = '<span class="text-slate-400">自動計算</span>';
         el.classList.remove("font-medium");
+        if (hiddenInput) hiddenInput.value = "";
       }
     });
   }

--- a/templates/form_public.html
+++ b/templates/form_public.html
@@ -912,6 +912,176 @@
     addGroupItem({ animate: false });
   }
 
+  // ---------- 計算フィールドのリアルタイム更新 ----------
+
+  function collectFormData(form) {
+    const data = {};
+    if (!form) return data;
+    const elements = form.querySelectorAll("input[name], select[name], textarea[name]");
+    elements.forEach((el) => {
+      const name = el.name;
+      if (!name) return;
+      // checkbox
+      if (el.type === "checkbox") {
+        if (!el.checked) return;
+      }
+      const parts = name.split(".");
+      let cursor = data;
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        const isLast = i === parts.length - 1;
+        const nextPart = parts[i + 1];
+        const nextIsIndex = nextPart !== undefined && /^\d+$/.test(nextPart);
+        if (isLast) {
+          // 同名が複数 → 配列
+          if (part in cursor) {
+            if (!Array.isArray(cursor[part])) {
+              cursor[part] = [cursor[part]];
+            }
+            cursor[part].push(el.value);
+          } else {
+            cursor[part] = el.value;
+          }
+        } else {
+          if (nextIsIndex) {
+            if (!(part in cursor)) cursor[part] = [];
+            cursor = cursor[part];
+          } else if (/^\d+$/.test(part)) {
+            const idx = parseInt(part, 10);
+            while (cursor.length <= idx) cursor.push({});
+            if (typeof cursor[idx] !== "object" || cursor[idx] === null) cursor[idx] = {};
+            cursor = cursor[idx];
+          } else {
+            if (!(part in cursor) || typeof cursor[part] !== "object" || cursor[part] === null) {
+              cursor[part] = {};
+            }
+            cursor = cursor[part];
+          }
+        }
+      }
+    });
+    return data;
+  }
+
+  function resolveValue(data, dottedKey) {
+    const parts = dottedKey.split(".");
+    let current = data;
+    for (let i = 0; i < parts.length; i++) {
+      if (current == null) return undefined;
+      if (Array.isArray(current)) {
+        const remaining = parts.slice(i);
+        const results = [];
+        for (const item of current) {
+          let sub = item;
+          for (const subPart of remaining) {
+            if (sub != null && typeof sub === "object" && !Array.isArray(sub)) {
+              sub = sub[subPart];
+            } else {
+              sub = undefined;
+              break;
+            }
+          }
+          if (sub !== undefined) results.push(sub);
+        }
+        return results.length > 0 ? results : undefined;
+      }
+      if (typeof current === "object") {
+        current = current[parts[i]];
+      } else {
+        return undefined;
+      }
+    }
+    return current;
+  }
+
+  function collectNumericValues(value) {
+    if (value == null) return [];
+    if (Array.isArray(value)) {
+      const result = [];
+      for (const item of value) {
+        const n = parseFloat(item);
+        if (!isNaN(n)) result.push(n);
+      }
+      return result;
+    }
+    const n = parseFloat(value);
+    return isNaN(n) ? [] : [n];
+  }
+
+  function applyAggregate(funcName, values) {
+    if (funcName === "count") return values.length;
+    if (values.length === 0) return 0;
+    if (funcName === "sum") return values.reduce((a, b) => a + b, 0);
+    if (funcName === "avg") return values.reduce((a, b) => a + b, 0) / values.length;
+    if (funcName === "max") return Math.max(...values);
+    if (funcName === "min") return Math.min(...values);
+    return 0;
+  }
+
+  function evaluateFormulaClient(formula, data) {
+    if (!formula) return null;
+    // 集約関数の置換
+    let expr = formula.replace(/(sum|avg|count|max|min)\(\{([A-Za-z][A-Za-z0-9_.]*)\}\)/g, (_, func, ref) => {
+      const value = resolveValue(data, ref);
+      const nums = collectNumericValues(value);
+      return String(applyAggregate(func, nums));
+    });
+    // フィールド参照の置換
+    expr = expr.replace(/\{([A-Za-z][A-Za-z0-9_.]*)\}/g, (_, ref) => {
+      const value = resolveValue(data, ref);
+      if (value == null) return "0";
+      const n = parseFloat(value);
+      return isNaN(n) ? "0" : String(n);
+    });
+    // 安全な評価: 数字・演算子・括弧・空白のみ許可
+    if (!/^[\d\s+\-*/%().eE]+$/.test(expr)) return null;
+    try {
+      const result = Function('"use strict"; return (' + expr + ')')();
+      if (typeof result === "number" && isFinite(result)) return result;
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  function updateCalculatedFields() {
+    const form = document.querySelector("form[method='post'][enctype='multipart/form-data']");
+    if (!form) return;
+    const data = collectFormData(form);
+    const displays = form.querySelectorAll("[data-role='calculated-display']");
+    displays.forEach((el) => {
+      const formula = el.dataset.formula;
+      if (!formula) return;
+      const result = evaluateFormulaClient(formula, data);
+      if (result !== null) {
+        const formatted = Number.isInteger(result) ? String(result) : result.toFixed(10).replace(/\.?0+$/, "");
+        el.textContent = formatted;
+        el.classList.remove("text-slate-400");
+        el.classList.add("text-slate-700", "font-medium");
+      } else {
+        el.innerHTML = '<span class="text-slate-400">自動計算</span>';
+        el.classList.remove("font-medium");
+      }
+    });
+  }
+
+  let calcTimer = 0;
+  function scheduleCalcUpdate() {
+    if (calcTimer) window.clearTimeout(calcTimer);
+    calcTimer = window.setTimeout(updateCalculatedFields, 120);
+  }
+
+  (function initCalculatedFieldWatcher() {
+    const form = document.querySelector("form[method='post'][enctype='multipart/form-data']");
+    if (!form) return;
+    form.addEventListener("input", scheduleCalcUpdate);
+    form.addEventListener("change", scheduleCalcUpdate);
+    // 初期表示
+    updateCalculatedFields();
+  })();
+
+  // ---------- /計算フィールドのリアルタイム更新 ----------
+
   preventSubmitOnEnter(document.querySelector("form[method='post'][enctype='multipart/form-data']"));
   document.querySelectorAll("input[data-picker]").forEach(initPicker);
   document.querySelectorAll(".array-field").forEach(initArrayFieldBlock);

--- a/templates/submission_edit.html
+++ b/templates/submission_edit.html
@@ -109,7 +109,7 @@
         {% endif %}
       </div>
       <div class="sf-field-input-col lg:col-span-9">
-        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula | e }}" data-key="{{ form_name }}">
+        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula_raw | e }}" data-key="{{ form_name }}">
           {{ current_value if current_value is not none else "自動計算" }}
         </div>
       </div>

--- a/templates/submission_edit.html
+++ b/templates/submission_edit.html
@@ -109,7 +109,7 @@
         {% endif %}
       </div>
       <div class="sf-field-input-col lg:col-span-9">
-        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0">
+        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula | e }}" data-key="{{ form_name }}">
           {{ current_value if current_value is not none else "自動計算" }}
         </div>
       </div>
@@ -950,6 +950,170 @@
       addGroupItem({ animate: false });
     }
   }
+
+  // ---------- 計算フィールドのリアルタイム更新 ----------
+
+  function collectFormData(form) {
+    const data = {};
+    if (!form) return data;
+    const elements = form.querySelectorAll("input[name], select[name], textarea[name]");
+    elements.forEach((el) => {
+      const name = el.name;
+      if (!name) return;
+      if (el.type === "checkbox") {
+        if (!el.checked) return;
+      }
+      const parts = name.split(".");
+      let cursor = data;
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        const isLast = i === parts.length - 1;
+        const nextPart = parts[i + 1];
+        const nextIsIndex = nextPart !== undefined && /^\d+$/.test(nextPart);
+        if (isLast) {
+          if (part in cursor) {
+            if (!Array.isArray(cursor[part])) {
+              cursor[part] = [cursor[part]];
+            }
+            cursor[part].push(el.value);
+          } else {
+            cursor[part] = el.value;
+          }
+        } else {
+          if (nextIsIndex) {
+            if (!(part in cursor)) cursor[part] = [];
+            cursor = cursor[part];
+          } else if (/^\d+$/.test(part)) {
+            const idx = parseInt(part, 10);
+            while (cursor.length <= idx) cursor.push({});
+            if (typeof cursor[idx] !== "object" || cursor[idx] === null) cursor[idx] = {};
+            cursor = cursor[idx];
+          } else {
+            if (!(part in cursor) || typeof cursor[part] !== "object" || cursor[part] === null) {
+              cursor[part] = {};
+            }
+            cursor = cursor[part];
+          }
+        }
+      }
+    });
+    return data;
+  }
+
+  function resolveValue(data, dottedKey) {
+    const parts = dottedKey.split(".");
+    let current = data;
+    for (let i = 0; i < parts.length; i++) {
+      if (current == null) return undefined;
+      if (Array.isArray(current)) {
+        const remaining = parts.slice(i);
+        const results = [];
+        for (const item of current) {
+          let sub = item;
+          for (const subPart of remaining) {
+            if (sub != null && typeof sub === "object" && !Array.isArray(sub)) {
+              sub = sub[subPart];
+            } else {
+              sub = undefined;
+              break;
+            }
+          }
+          if (sub !== undefined) results.push(sub);
+        }
+        return results.length > 0 ? results : undefined;
+      }
+      if (typeof current === "object") {
+        current = current[parts[i]];
+      } else {
+        return undefined;
+      }
+    }
+    return current;
+  }
+
+  function collectNumericValues(value) {
+    if (value == null) return [];
+    if (Array.isArray(value)) {
+      const result = [];
+      for (const item of value) {
+        const n = parseFloat(item);
+        if (!isNaN(n)) result.push(n);
+      }
+      return result;
+    }
+    const n = parseFloat(value);
+    return isNaN(n) ? [] : [n];
+  }
+
+  function applyAggregate(funcName, values) {
+    if (funcName === "count") return values.length;
+    if (values.length === 0) return 0;
+    if (funcName === "sum") return values.reduce((a, b) => a + b, 0);
+    if (funcName === "avg") return values.reduce((a, b) => a + b, 0) / values.length;
+    if (funcName === "max") return Math.max(...values);
+    if (funcName === "min") return Math.min(...values);
+    return 0;
+  }
+
+  function evaluateFormulaClient(formula, data) {
+    if (!formula) return null;
+    let expr = formula.replace(/(sum|avg|count|max|min)\(\{([A-Za-z][A-Za-z0-9_.]*)\}\)/g, (_, func, ref) => {
+      const value = resolveValue(data, ref);
+      const nums = collectNumericValues(value);
+      return String(applyAggregate(func, nums));
+    });
+    expr = expr.replace(/\{([A-Za-z][A-Za-z0-9_.]*)\}/g, (_, ref) => {
+      const value = resolveValue(data, ref);
+      if (value == null) return "0";
+      const n = parseFloat(value);
+      return isNaN(n) ? "0" : String(n);
+    });
+    if (!/^[\d\s+\-*/%().eE]+$/.test(expr)) return null;
+    try {
+      const result = Function('"use strict"; return (' + expr + ')')();
+      if (typeof result === "number" && isFinite(result)) return result;
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  function updateCalculatedFields() {
+    const form = document.querySelector("form[method='post'][enctype='multipart/form-data']");
+    if (!form) return;
+    const data = collectFormData(form);
+    const displays = form.querySelectorAll("[data-role='calculated-display']");
+    displays.forEach((el) => {
+      const formula = el.dataset.formula;
+      if (!formula) return;
+      const result = evaluateFormulaClient(formula, data);
+      if (result !== null) {
+        const formatted = Number.isInteger(result) ? String(result) : result.toFixed(10).replace(/\.?0+$/, "");
+        el.textContent = formatted;
+        el.classList.remove("text-slate-400");
+        el.classList.add("text-slate-700", "font-medium");
+      } else {
+        el.innerHTML = '<span class="text-slate-400">自動計算</span>';
+        el.classList.remove("font-medium");
+      }
+    });
+  }
+
+  let calcTimer = 0;
+  function scheduleCalcUpdate() {
+    if (calcTimer) window.clearTimeout(calcTimer);
+    calcTimer = window.setTimeout(updateCalculatedFields, 120);
+  }
+
+  (function initCalculatedFieldWatcher() {
+    const form = document.querySelector("form[method='post'][enctype='multipart/form-data']");
+    if (!form) return;
+    form.addEventListener("input", scheduleCalcUpdate);
+    form.addEventListener("change", scheduleCalcUpdate);
+    updateCalculatedFields();
+  })();
+
+  // ---------- /計算フィールドのリアルタイム更新 ----------
 
   preventSubmitOnEnter(document.querySelector("form[method='post'][enctype='multipart/form-data']"));
   document.querySelectorAll("input[data-picker]").forEach(initPicker);

--- a/templates/submission_edit.html
+++ b/templates/submission_edit.html
@@ -96,6 +96,26 @@
   </div>
   {% endif %}
 
+{% elif field.type == "calculated" %}
+  {# 計算フィールド (読み取り専用) #}
+  <div class="py-2 lg:py-3">
+    <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">
+      <div class="lg:col-span-3">
+        <label class="block text-sm font-semibold leading-6">
+          {{ field.label or field.key }}
+        </label>
+        {% if field.description %}
+        <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">{{ field.description }}</div>
+        {% endif %}
+      </div>
+      <div class="sf-field-input-col lg:col-span-9">
+        <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0">
+          {{ current_value if current_value is not none else "自動計算" }}
+        </div>
+      </div>
+    </div>
+  </div>
+
 {% else %}
   {% set ns = namespace(fw="max-w-md") %}
   {% if field.type in ["number", "integer"] %}

--- a/templates/submission_edit.html
+++ b/templates/submission_edit.html
@@ -112,6 +112,7 @@
         <div class="mt-1 w-full max-w-[10rem] rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0" data-role="calculated-display" data-formula="{{ field.formula_raw | e }}" data-key="{{ form_name }}">
           {{ current_value if current_value is not none else "自動計算" }}
         </div>
+        <input type="hidden" name="{{ form_name }}" data-role="calculated-value" value="{{ current_value if current_value is not none else '' }}">
       </div>
     </div>
   </div>
@@ -1087,14 +1088,17 @@
       const formula = el.dataset.formula;
       if (!formula) return;
       const result = evaluateFormulaClient(formula, data);
+      const hiddenInput = el.parentElement.querySelector("[data-role='calculated-value']");
       if (result !== null) {
         const formatted = Number.isInteger(result) ? String(result) : result.toFixed(10).replace(/\.?0+$/, "");
         el.textContent = formatted;
         el.classList.remove("text-slate-400");
         el.classList.add("text-slate-700", "font-medium");
+        if (hiddenInput) hiddenInput.value = result;
       } else {
         el.innerHTML = '<span class="text-slate-400">自動計算</span>';
         el.classList.remove("font-medium");
+        if (hiddenInput) hiddenInput.value = "";
       }
     });
   }


### PR DESCRIPTION
## Summary
- 計算式でフィールド値を自動計算する「計算」フィールドタイプを追加
- `{フィールドキー}` 構文で数値フィールドを参照し、四則演算 (`+`, `-`, `*`, `/`) をサポート
- 配列フィールドに対する集約関数: `sum()`, `avg()`, `count()`, `max()`, `min()`
- ASTベースのホワイトリスト方式による安全な式評価

## 変更内容
- `src/schemaform/calculated.py` (新規): 計算式パーサーと評価エンジン
- `src/schemaform/config.py`: `ALLOWED_TYPES` に `calculated` を追加
- `src/schemaform/schema.py`: 計算フィールドのパース・JSON Schema変換・復元
- `src/schemaform/routes/public.py`: 公開フォーム送信時の計算実行
- `src/schemaform/routes/api.py`: API送信時の計算実行
- `src/schemaform/routes/submissions.py`: 送信編集時の計算実行
- `templates/admin_form_builder.html`: フォームビルダーに「計算」タイプと計算式入力UI
- `templates/form_public.html`: 計算フィールドの読み取り専用表示
- `templates/submission_edit.html`: 編集画面での計算フィールド表示

## 使い方
フォームビルダーで「計算」タイプを選択し、計算式を入力します。

| 計算式の例 | 説明 |
|---|---|
| `{price} * {quantity}` | 単価 × 数量 |
| `({price} - {discount}) * 1.1` | 割引後に税率を掛ける |
| `sum({items.amount})` | 配列フィールドの合計 |
| `avg({scores})` | 配列フィールドの平均 |
| `count({items})` / `max({vals})` / `min({vals})` | 件数・最大値・最小値 |

## Test plan
- [ ] フォームビルダーで「計算」タイプを選択し、計算式を入力して保存
- [ ] `{price} * {quantity}` のような基本的な計算式で正しく計算されることを確認
- [ ] `sum({items.amount})` のような配列集約関数が動作することを確認
- [ ] 不正な計算式（`import os` 等）がバリデーションで弾かれることを確認
- [ ] 0除算がエラーにならず安全に処理されることを確認
- [ ] APIからの送信でも計算フィールドが正しく計算されることを確認
- [ ] 送信編集画面で計算フィールドが読み取り専用で表示されることを確認