### PR TITLE
テーブルのth/tdにwhitespace-nowrapを適用しbrタグ以外での改行を防止

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,11 @@
       label {
         touch-action: manipulation;
       }
+
+      table th,
+      table td {
+        white-space: nowrap;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-slate-50 text-slate-900">


### PR DESCRIPTION
テーブル内のテキスト折り返しをしないようにします