### PR TITLE
user-permission v0.3.0 対応

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ulid-py>=1.1.0",
     "typer>=0.12.0",
     "httpx>=0.27.0",
-    "user-permission[fastapi,relay]>=0.2.0",
+    "user-permission[fastapi,relay]>=0.3.0",
 ]
 
 [project.scripts]

--- a/src/schemaform/auth.py
+++ b/src/schemaform/auth.py
@@ -132,9 +132,7 @@ class UserPermissionAuthProvider:
         user_id, username = verified
         group_info = await self._fetch_groups(user_id, token)
         group_names = [name for name, _ in group_info]
-        is_admin = any(flag for _, flag in group_info) or (
-            self._admin_group in group_names
-        )
+        is_admin = any(flag for _, flag in group_info)
         request.state.current_user = {
             "id": user_id,
             "username": username,

--- a/src/schemaform/auth.py
+++ b/src/schemaform/auth.py
@@ -108,13 +108,15 @@ class UserPermissionAuthProvider:
         except Exception:
             return None
 
-    async def _fetch_groups(self, user_id: int, token: str) -> list[str]:
+    async def _fetch_groups(
+        self, user_id: int, token: str
+    ) -> list[tuple[str, bool]]:
         try:
             if self._is_relay:
                 groups = await self._db.groups.get_user_groups(user_id, token)
             else:
                 groups = await self._db.groups.get_user_groups(user_id)
-            return [g.name for g in groups]
+            return [(g.name, bool(getattr(g, "is_admin", False))) for g in groups]
         except Exception:
             return []
 
@@ -128,13 +130,17 @@ class UserPermissionAuthProvider:
             request.state.current_user = None
             return
         user_id, username = verified
-        groups = await self._fetch_groups(user_id, token)
+        group_info = await self._fetch_groups(user_id, token)
+        group_names = [name for name, _ in group_info]
+        is_admin = any(flag for _, flag in group_info) or (
+            self._admin_group in group_names
+        )
         request.state.current_user = {
             "id": user_id,
             "username": username,
             "token": token,
-            "groups": groups,
-            "is_admin": self._admin_group in groups,
+            "groups": group_names,
+            "is_admin": is_admin,
         }
 
     async def require_login(self, request: Request) -> dict[str, Any]:
@@ -180,8 +186,12 @@ class UserPermissionAuthProvider:
         group = await self._db.groups.get_by_name(self._admin_group)
         if group is None:
             group = await self._db.groups.create(
-                self._admin_group, description="管理者グループ"
+                self._admin_group, description="管理者グループ", is_admin=True
             )
+        elif not getattr(group, "is_admin", False):
+            updated = await self._db.groups.update(group.id, is_admin=True)
+            if updated is not None:
+                group = updated
         members = await self._db.groups.get_members(group.id)
         if members:
             return None

--- a/src/schemaform/cli.py
+++ b/src/schemaform/cli.py
@@ -188,9 +188,16 @@ async def _create_admin(
         group = await db.groups.get_by_name(group_name)
         if group is None:
             group = await db.groups.create(
-                group_name, description="管理者グループ"
+                group_name, description="管理者グループ", is_admin=True
             )
             typer.echo(f"グループを作成しました: {group.name} (id={group.id})")
+        elif not getattr(group, "is_admin", False):
+            updated = await db.groups.update(group.id, is_admin=True)
+            if updated is not None:
+                group = updated
+                typer.echo(
+                    f"グループを管理者グループに昇格しました: {group.name} (id={group.id})"
+                )
 
         added = await db.groups.add_user(group.id, user.id)
         if added:

--- a/uv.lock
+++ b/uv.lock
@@ -754,7 +754,7 @@ requires-dist = [
     { name = "tinydb", specifier = ">=4.8.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "ulid-py", specifier = ">=1.1.0" },
-    { name = "user-permission", extras = ["fastapi", "relay"], specifier = ">=0.2.0" },
+    { name = "user-permission", extras = ["fastapi", "relay"], specifier = ">=0.3.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
@@ -878,16 +878,16 @@ wheels = [
 
 [[package]]
 name = "user-permission"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "pwdlib", extra = ["argon2"] },
     { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/15/b2297fd520fb0753040bca17bca1d82bf0cc1e393e8bf46aa6a8dbd282bb/user_permission-0.2.0.tar.gz", hash = "sha256:fd58cac3cf1711754534487571a90837eecf5c47b904bd8a3799b0259b50c357", size = 15892, upload-time = "2026-04-12T15:42:14.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/d7/276cec637a08189e699eef3e0131ae4ad1b57ac605b796eba96b62442111/user_permission-0.3.0.tar.gz", hash = "sha256:56a93ce7e43d64e617efb7feebf6486f81da3e4a94a75f2eafbf3e66c4ca6175", size = 25640, upload-time = "2026-04-15T03:19:20.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/7d/3c3e2c45f6c12eb875483adb8e576f1ddd54f7811b4e466dd995cf1ddb76/user_permission-0.2.0-py3-none-any.whl", hash = "sha256:3761adcbb1f7ad362368f2c72e1ab02ca78b46c668c63416bed4586310587747", size = 21294, upload-time = "2026-04-12T15:42:16.07Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/112a8f26296cb39ce3bdacc9e2c795dde3f3c421a09c76ae510acf01796e/user_permission-0.3.0-py3-none-any.whl", hash = "sha256:036b3436268623adb187f6d69ebe947efc93072130dfa84698daa47d47c441c7", size = 31828, upload-time = "2026-04-15T03:19:19.052Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
v0.3.0 で導入された Group.is_admin フィールドを利用して管理者判定を行うように変更。
管理者グループを作成／取得する際に is_admin=True を付与し、既存の管理者グループにも
昇格（update）を行うことで v0.2.0 からの移行を透過的にサポートする。