### PR TITLE
フォーム一覧の説明文に最大幅と折り返しを適用

### DIFF
--- a/templates/admin_forms.html
+++ b/templates/admin_forms.html
@@ -51,7 +51,7 @@
       <tr>
         <td class="px-4 py-3 font-medium">
           <div class="whitespace-nowrap text-slate-900">{{ form.name }}</div>
-          <div class="text-xs text-slate-500">{{ form.description }}</div>
+          <div class="max-w-md whitespace-normal break-all text-xs text-slate-500">{{ form.description }}</div>
         </td>
         <td class="px-4 py-3">
           {% if form.status == "active" %}

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -39,7 +39,7 @@
       <tr>
         <td class="px-4 py-3 font-medium">
           <div class="whitespace-nowrap text-slate-900">{{ form.name }}</div>
-          <div class="text-xs text-slate-500">{{ form.description }}</div>
+          <div class="max-w-md whitespace-normal break-all text-xs text-slate-500">{{ form.description }}</div>
         </td>
         <td class="px-4 py-3">
           <div class="flex flex-nowrap gap-2 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- フォーム一覧ページの説明文セル内 `<div>` に `max-w-md whitespace-normal break-all` を付与し、`base.html` の `table td { white-space: nowrap }` を個別に上書き
- 管理者用 (`templates/admin_forms.html`) と一般ユーザー用 (`templates/forms.html`) の両方に適用
- 長い説明文で横スクロールが発生していた問題を解消し、28rem を超える場合は折り返すように変更
- 日本語には単語区切りがないため `break-words` ではなく `break-all` を採用

## Test plan
- [x] `/forms` で長い説明文を持つフォームが `max-w-md` (448px) 幅で折り返されることを確認
- [x] フォーム名・ページ遷移・更新日時の各列は従来どおり1行表示を維持
- [x] 横スクロールが発生しないことを確認
