### PR TITLE
ファイルフィールドのメディアプレビュー機能を追加

### DIFF
--- a/src/schemaform/file_formats.py
+++ b/src/schemaform/file_formats.py
@@ -207,3 +207,28 @@ def upload_matches_file_constraints(
     if normalize_allowed_extensions(allowed_extensions):
         return upload_matches_allowed_extensions(filename, allowed_extensions)
     return upload_matches_file_format(content_type, filename, file_format)
+
+
+def media_kind_for_file(content_type: object, filename: object) -> str:
+    """ブラウザ上で表示/再生できるメディア種別を返す。
+
+    該当しない場合は空文字を返す。
+    """
+    media_type = str(content_type or "").strip().lower()
+    if media_type.startswith("image/"):
+        return FILE_FORMAT_IMAGE
+    if media_type.startswith("video/"):
+        return FILE_FORMAT_VIDEO
+    if media_type.startswith("audio/"):
+        return FILE_FORMAT_AUDIO
+
+    extension = normalize_extension(Path(str(filename or "")).suffix)
+    if not extension:
+        return ""
+    if extension in IMAGE_EXTENSIONS:
+        return FILE_FORMAT_IMAGE
+    if extension in VIDEO_EXTENSIONS:
+        return FILE_FORMAT_VIDEO
+    if extension in AUDIO_EXTENSIONS:
+        return FILE_FORMAT_AUDIO
+    return ""

--- a/src/schemaform/filters.py
+++ b/src/schemaform/filters.py
@@ -12,6 +12,7 @@ from schemaform.fields import (
     format_array_group_value,
     get_nested_value,
 )
+from schemaform.file_formats import media_kind_for_file
 from schemaform.protocols import FileRepository
 
 
@@ -66,13 +67,33 @@ def collect_file_ids(
     return ids
 
 
-def resolve_file_names(file_repo: FileRepository, file_ids: Iterable[str]) -> dict[str, str]:
-    mapping: dict[str, str] = {}
+def resolve_file_infos(
+    file_repo: FileRepository, file_ids: Iterable[str]
+) -> dict[str, dict[str, str]]:
+    """file_id → {name, content_type, kind} のマップを返す。
+
+    kind は "image"/"video"/"audio" もしくは空文字（ブラウザ上で表示/再生に適さない場合）。
+    """
+    mapping: dict[str, dict[str, str]] = {}
     for file_id in file_ids:
         file_meta = file_repo.get_file(file_id)
-        if file_meta:
-            mapping[file_id] = file_meta.get("original_name", "")
+        if not file_meta:
+            continue
+        name = str(file_meta.get("original_name", "") or "")
+        content_type = str(file_meta.get("content_type", "") or "")
+        mapping[file_id] = {
+            "name": name,
+            "content_type": content_type,
+            "kind": media_kind_for_file(content_type, name),
+        }
     return mapping
+
+
+def resolve_file_names(file_repo: FileRepository, file_ids: Iterable[str]) -> dict[str, str]:
+    return {
+        file_id: info["name"]
+        for file_id, info in resolve_file_infos(file_repo, file_ids).items()
+    }
 
 
 def value_to_text(value: Any, file_names: dict[str, str], use_file_names: bool) -> str:

--- a/src/schemaform/master.py
+++ b/src/schemaform/master.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from schemaform.fields import expand_group_array_rows
@@ -334,7 +335,7 @@ def _collect_candidate_fields(
             )
             continue
 
-        if field_type != "file" and full_key not in seen_keys:
+        if full_key not in seen_keys:
             candidates.append(
                 {
                     "key": full_key,
@@ -656,6 +657,42 @@ def enrich_master_options(storage: Any, fields: list[dict[str, Any]]) -> None:
                 }
             )
         field["master_options"] = options
+
+
+def collect_master_display_file_ids(fields: list[dict[str, Any]]) -> set[str]:
+    """参照フィールドの display 項目からファイル ID を収集する。"""
+    ids: set[str] = set()
+    for field in fields:
+        if field.get("type") == "group":
+            ids |= collect_master_display_file_ids(field.get("children") or [])
+            continue
+        if field.get("type") != "master":
+            continue
+        display_items = field.get("master_display_items") or []
+        file_keys = [
+            item.get("key")
+            for item in display_items
+            if item.get("type") == "file" and item.get("key")
+        ]
+        if not file_keys:
+            continue
+        for option in field.get("master_options") or []:
+            raw = option.get("display_json") or "{}"
+            try:
+                parsed = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            for key in file_keys:
+                value = parsed.get(key)
+                if not value:
+                    continue
+                for token in str(value).split(","):
+                    token = token.strip()
+                    if token:
+                        ids.add(token)
+    return ids
 
 
 def _extract_base_id(value: Any) -> str:

--- a/src/schemaform/routes/public.py
+++ b/src/schemaform/routes/public.py
@@ -10,8 +10,12 @@ from jsonschema import Draft7Validator
 from schemaform.calculated import evaluate_formula
 from schemaform.file_formats import upload_matches_file_constraints
 from schemaform.fields import clean_empty_recursive
-from schemaform.filters import normalize_number, parse_bool
-from schemaform.master import enrich_master_options, validate_master_references
+from schemaform.filters import normalize_number, parse_bool, resolve_file_infos
+from schemaform.master import (
+    collect_master_display_file_ids,
+    enrich_master_options,
+    validate_master_references,
+)
 from schemaform.schema import fields_from_schema
 from schemaform.utils import new_ulid, now_utc
 
@@ -68,6 +72,9 @@ async def public_form(request: Request, public_id: str) -> HTMLResponse:
         raise HTTPException(status_code=404, detail="フォームが見つかりません")
     fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
     enrich_master_options(storage, fields)
+    file_infos = resolve_file_infos(
+        storage.files, collect_master_display_file_ids(fields)
+    )
     inactive = form.get("status") != "active"
     errors = ["このフォームは停止中です"] if inactive else []
     return templates.TemplateResponse(
@@ -76,6 +83,7 @@ async def public_form(request: Request, public_id: str) -> HTMLResponse:
             "request": request,
             "form": form,
             "fields": fields,
+            "file_infos": file_infos,
             "errors": errors,
             "inactive": inactive,
         },
@@ -92,12 +100,16 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
     if form.get("status") != "active":
         fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
         enrich_master_options(storage, fields)
+        file_infos = resolve_file_infos(
+            storage.files, collect_master_display_file_ids(fields)
+        )
         return templates.TemplateResponse(
             "form_public.html",
             {
                 "request": request,
                 "form": form,
                 "fields": fields,
+                "file_infos": file_infos,
                 "errors": ["このフォームは停止中です"],
                 "inactive": True,
             },
@@ -223,12 +235,16 @@ async def submit_form(request: Request, public_id: str) -> HTMLResponse:
     master_errors = validate_master_references(storage, fields, submission)
     if errors or master_errors:
         messages = [f"{error.message}" for error in errors] + master_errors
+        file_infos = resolve_file_infos(
+            storage.files, collect_master_display_file_ids(fields)
+        )
         return templates.TemplateResponse(
             "form_public.html",
             {
                 "request": request,
                 "form": form,
                 "fields": fields,
+                "file_infos": file_infos,
                 "errors": messages,
                 "inactive": False,
             },

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -23,6 +23,7 @@ from schemaform.filters import (
     collect_file_ids,
     normalize_number,
     parse_bool,
+    resolve_file_infos,
     resolve_file_names,
     value_to_text,
 )
@@ -88,6 +89,7 @@ def build_submission_display_columns(
                         "label": f"{field['flat_label']}.{item['label']}",
                         "field": field,
                         "display_key": item["key"],
+                        "display_type": item.get("type", ""),
                     }
                 )
 
@@ -235,6 +237,92 @@ def build_submission_row_values(
     return row_values
 
 
+def _resolve_master_display_raw(
+    raw_value: Any,
+    lookup: dict[str, dict[str, Any]],
+    display_key: str,
+) -> Any:
+    """参照フィールドの表示用ファイル値を生ID (またはID配列) で返す。"""
+
+    def resolve_one(value: Any) -> Any:
+        if value in (None, ""):
+            return None
+        row = lookup.get(str(value))
+        if not row:
+            return None
+        return (row.get("values") or {}).get(display_key)
+
+    if isinstance(raw_value, list):
+        items: list[Any] = []
+        for item in raw_value:
+            resolved = resolve_one(item)
+            if isinstance(resolved, list):
+                items.extend(resolved)
+            elif resolved not in (None, ""):
+                items.append(resolved)
+        return items
+    return resolve_one(raw_value)
+
+
+def build_submission_raw_values(
+    data: dict[str, Any],
+    display_columns: list[dict[str, Any]],
+    master_lookup_by_field: dict[str, dict[str, dict[str, Any]]] | None = None,
+) -> list[Any]:
+    """ファイルフィールドのプレビュー表示などで元の値が必要な箇所向けに、
+    列ごとの生の値（ID・配列など）を返す。"""
+    master_lookup_by_field = master_lookup_by_field or {}
+    result: list[Any] = []
+    for column in display_columns:
+        field = column["field"]
+        flat_key = field["flat_key"]
+        raw = get_nested_value(data, flat_key)
+        if (
+            column.get("kind") == "master_display"
+            and column.get("display_type") == "file"
+        ):
+            lookup = master_lookup_by_field.get(flat_key, {})
+            raw = _resolve_master_display_raw(
+                raw, lookup, str(column.get("display_key", ""))
+            )
+        result.append(raw)
+    return result
+
+
+def collect_master_display_file_ids(
+    submissions: list[dict[str, Any]],
+    display_columns: list[dict[str, Any]],
+    master_lookup_by_field: dict[str, dict[str, dict[str, Any]]],
+) -> set[str]:
+    """参照フィールド越しに表示されるファイルの ID を収集する。"""
+    ids: set[str] = set()
+    file_columns = [
+        column
+        for column in display_columns
+        if column.get("kind") == "master_display"
+        and column.get("display_type") == "file"
+    ]
+    if not file_columns:
+        return ids
+    for submission in submissions:
+        data = submission.get("data_json", {})
+        for column in file_columns:
+            flat_key = column["field"]["flat_key"]
+            lookup = master_lookup_by_field.get(flat_key, {})
+            raw = _resolve_master_display_raw(
+                get_nested_value(data, flat_key),
+                lookup,
+                str(column.get("display_key", "")),
+            )
+            if isinstance(raw, list):
+                for item in raw:
+                    if isinstance(item, str) and item:
+                        ids.add(item)
+            elif isinstance(raw, str) and raw:
+                ids.add(raw)
+    return ids
+
+
 @router.get(
     "/admin/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["admin"]
 )
@@ -255,14 +343,18 @@ async def list_submissions(
         for expanded_data in expand_group_array_rows(fields, data):
             expanded_submissions.append({**submission, "data_json": expanded_data})
     file_ids = collect_file_ids(submissions, fields)
-    file_names = resolve_file_names(storage.files, file_ids)
-
-    filtered = apply_filters(
-        expanded_submissions, fields, dict(request.query_params), file_names=file_names
-    )
 
     display_columns, master_lookup_by_field = build_submission_display_columns(
         storage, fields
+    )
+    file_ids |= collect_master_display_file_ids(
+        submissions, display_columns, master_lookup_by_field
+    )
+    file_infos = resolve_file_infos(storage.files, file_ids)
+    file_names = {fid: info["name"] for fid, info in file_infos.items()}
+
+    filtered = apply_filters(
+        expanded_submissions, fields, dict(request.query_params), file_names=file_names
     )
 
     sort = request.query_params.get("sort", "created_at")
@@ -295,12 +387,16 @@ async def list_submissions(
             master_lookup_by_field,
             file_names,
         )
+        raw_values = build_submission_raw_values(
+            data, display_columns, master_lookup_by_field
+        )
         display_rows.append(
             {
                 "id": item["id"],
                 "created_at": item["created_at"],
                 "updated_at": item.get("updated_at"),
                 "values": row_values,
+                "raw_values": raw_values,
             }
         )
 
@@ -315,6 +411,7 @@ async def list_submissions(
             "display_columns": display_columns,
             "filter_fields": filter_fields,
             "rows": display_rows,
+            "file_infos": file_infos,
             "page": page,
             "page_size": page_size,
             "total": total,
@@ -369,6 +466,8 @@ async def edit_submission(
         raise HTTPException(status_code=404, detail="送信データが見つかりません")
     fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
     enrich_master_options(storage, fields)
+    file_ids = collect_file_ids([submission], fields)
+    file_infos = resolve_file_infos(storage.files, file_ids)
     return templates.TemplateResponse(
         "submission_edit.html",
         {
@@ -376,6 +475,7 @@ async def edit_submission(
             "form": form,
             "fields": fields,
             "submission": submission,
+            "file_infos": file_infos,
             "errors": [],
         },
     )
@@ -537,6 +637,8 @@ async def update_submission(
     master_errors = validate_master_references(storage, fields, submission)
     if errors or master_errors:
         messages = [f"{error.message}" for error in errors] + master_errors
+        file_ids = collect_file_ids([{**existing, "data_json": submission}], fields)
+        file_infos = resolve_file_infos(storage.files, file_ids)
         return templates.TemplateResponse(
             "submission_edit.html",
             {
@@ -544,6 +646,7 @@ async def update_submission(
                 "form": form,
                 "fields": fields,
                 "submission": {**existing, "data_json": submission},
+                "file_infos": file_infos,
                 "errors": messages,
             },
         )

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -289,12 +289,12 @@ def build_submission_raw_values(
     return result
 
 
-def collect_master_display_file_ids(
+def collect_submission_master_display_file_ids(
     submissions: list[dict[str, Any]],
     display_columns: list[dict[str, Any]],
     master_lookup_by_field: dict[str, dict[str, dict[str, Any]]],
 ) -> set[str]:
-    """参照フィールド越しに表示されるファイルの ID を収集する。"""
+    """送信一覧で参照フィールド越しに表示されるファイルの ID を収集する。"""
     ids: set[str] = set()
     file_columns = [
         column
@@ -347,7 +347,7 @@ async def list_submissions(
     display_columns, master_lookup_by_field = build_submission_display_columns(
         storage, fields
     )
-    file_ids |= collect_master_display_file_ids(
+    file_ids |= collect_submission_master_display_file_ids(
         submissions, display_columns, master_lookup_by_field
     )
     file_infos = resolve_file_infos(storage.files, file_ids)

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -18,7 +18,7 @@ from schemaform.routes.submissions import (
     build_submission_display_columns,
     build_submission_raw_values,
     build_submission_row_values,
-    collect_master_display_file_ids,
+    collect_submission_master_display_file_ids,
     sort_submissions,
 )
 from schemaform.schema import fields_from_schema
@@ -94,7 +94,7 @@ async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
     display_columns, master_lookup_by_field = build_submission_display_columns(
         storage, fields
     )
-    file_ids |= collect_master_display_file_ids(
+    file_ids |= collect_submission_master_display_file_ids(
         submissions, display_columns, master_lookup_by_field
     )
     file_infos = resolve_file_infos(storage.files, file_ids)

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -12,11 +12,13 @@ from schemaform.fields import (
 from schemaform.filters import (
     apply_filters,
     collect_file_ids,
-    resolve_file_names,
+    resolve_file_infos,
 )
 from schemaform.routes.submissions import (
     build_submission_display_columns,
+    build_submission_raw_values,
     build_submission_row_values,
+    collect_master_display_file_ids,
     sort_submissions,
 )
 from schemaform.schema import fields_from_schema
@@ -88,17 +90,21 @@ async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
         for expanded_data in expand_group_array_rows(fields, data):
             expanded_submissions.append({**submission, "data_json": expanded_data})
     file_ids = collect_file_ids(submissions, fields)
-    file_names = resolve_file_names(storage.files, file_ids)
+
+    display_columns, master_lookup_by_field = build_submission_display_columns(
+        storage, fields
+    )
+    file_ids |= collect_master_display_file_ids(
+        submissions, display_columns, master_lookup_by_field
+    )
+    file_infos = resolve_file_infos(storage.files, file_ids)
+    file_names = {fid: info["name"] for fid, info in file_infos.items()}
 
     filtered = apply_filters(
         expanded_submissions,
         fields,
         dict(request.query_params),
         file_names=file_names,
-    )
-
-    display_columns, master_lookup_by_field = build_submission_display_columns(
-        storage, fields
     )
 
     sort = request.query_params.get("sort", "created_at")
@@ -131,6 +137,9 @@ async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
             master_lookup_by_field,
             file_names,
         )
+        raw_values = build_submission_raw_values(
+            data, display_columns, master_lookup_by_field
+        )
         display_rows.append(
             {
                 "id": item["id"],
@@ -139,6 +148,7 @@ async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
                 "user_id": item.get("user_id"),
                 "username": item.get("username"),
                 "values": row_values,
+                "raw_values": raw_values,
             }
         )
 
@@ -164,6 +174,7 @@ async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
             "display_columns": display_columns,
             "filter_fields": filter_fields,
             "rows": display_rows,
+            "file_infos": file_infos,
             "page": page,
             "page_size": page_size,
             "total": total,
@@ -200,6 +211,8 @@ async def edit_submission(
 
     fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
     enrich_master_options(storage, fields)
+    file_ids = collect_file_ids([submission], fields)
+    file_infos = resolve_file_infos(storage.files, file_ids)
     return templates.TemplateResponse(
         "submission_edit.html",
         {
@@ -207,6 +220,7 @@ async def edit_submission(
             "form": form,
             "fields": fields,
             "submission": submission,
+            "file_infos": file_infos,
             "errors": [],
             "cancel_url": f"/forms/{form_id}/submissions",
             "action_url": f"/forms/{form_id}/submissions/{submission_id}/edit",

--- a/templates/_file_preview.html
+++ b/templates/_file_preview.html
@@ -1,0 +1,66 @@
+{# ファイルフィールドの値をプレビュー付きで表示するためのマクロ集。
+
+file_infos は {file_id: {name, content_type, kind}} の辞書。
+kind は "image"/"video"/"audio" またはそれ以外 (空文字) で、
+ブラウザ上で直接表示/再生できる場合のみ指定される。 #}
+
+{% macro file_media_preview(file_id, info, size="md") -%}
+  {% set name = info.name or file_id %}
+  {% set kind = info.kind or "" %}
+  {% if size == "sm" %}
+    {% set img_class = "max-h-16 max-w-[8rem] rounded border border-slate-200 object-contain" %}
+    {% set video_class = "max-h-20 max-w-[10rem] rounded border border-slate-200" %}
+  {% else %}
+    {% set img_class = "max-h-40 max-w-xs rounded border border-slate-200 object-contain" %}
+    {% set video_class = "max-h-48 max-w-sm rounded border border-slate-200" %}
+  {% endif %}
+  {% if kind == "image" %}
+    <img src="/files/{{ file_id }}" alt="{{ name }}" loading="lazy" class="{{ img_class }} cursor-pointer" data-lightbox="/files/{{ file_id }}" data-lightbox-kind="image" data-lightbox-name="{{ name }}" />
+  {% elif kind == "video" %}
+    <div class="{{ video_class }} flex items-center justify-center bg-slate-100 cursor-pointer" data-lightbox="/files/{{ file_id }}" data-lightbox-kind="video" data-lightbox-name="{{ name }}">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-slate-400" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+    </div>
+  {% elif kind == "audio" %}
+    <audio src="/files/{{ file_id }}" controls preload="metadata" class="w-full max-w-xs"></audio>
+  {% endif %}
+{%- endmacro %}
+
+{% macro file_link(file_id, info) -%}
+  {% set name = info.name or file_id %}
+  <a href="/files/{{ file_id }}" target="_blank" rel="noopener noreferrer" class="break-all text-sky-700 underline">{{ name }}</a>
+{%- endmacro %}
+
+{% macro file_entry(file_id, file_infos, size="md") -%}
+  {% if not file_id %}{% else %}
+    {% set info = file_infos.get(file_id) if file_infos else none %}
+    {% if info %}
+      {% if info.kind %}
+        <div class="space-y-1">
+          {{ file_media_preview(file_id, info, size) }}
+          <div class="text-xs text-slate-500 break-all">{{ file_link(file_id, info) }}</div>
+        </div>
+      {% else %}
+        {{ file_link(file_id, info) }}
+      {% endif %}
+    {% else %}
+      <span class="text-slate-500">{{ file_id }}</span>
+    {% endif %}
+  {% endif %}
+{%- endmacro %}
+
+{% macro file_value(value, file_infos, size="md") -%}
+  {% if value is iterable and value is not string and value is not mapping %}
+    {% set items = value | list %}
+    {% if items %}
+      <div class="flex flex-wrap gap-2">
+        {% for item in items %}
+          {% if item %}
+          <div>{{ file_entry(item, file_infos, size) }}</div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% elif value %}
+    {{ file_entry(value, file_infos, size) }}
+  {% endif %}
+{%- endmacro %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -101,5 +101,65 @@
     <main class="mx-auto max-w-6xl px-6 py-8">
       {% block content %}{% endblock %}
     </main>
+
+    <div id="lightbox-overlay" class="fixed inset-0 z-[100] hidden items-center justify-center bg-black/80 p-4" role="dialog" aria-modal="true">
+      <button type="button" id="lightbox-close" class="absolute right-4 top-4 z-10 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white hover:bg-black/70" aria-label="閉じる">✕</button>
+      <a id="lightbox-download" href="#" target="_blank" rel="noopener noreferrer" class="absolute left-4 top-4 z-10 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white hover:bg-black/70">ダウンロード</a>
+      <div id="lightbox-content" class="flex max-h-full max-w-full items-center justify-center"></div>
+    </div>
+    <script>
+      (() => {
+        const overlay = document.getElementById("lightbox-overlay");
+        const content = document.getElementById("lightbox-content");
+        const closeBtn = document.getElementById("lightbox-close");
+        const downloadLink = document.getElementById("lightbox-download");
+        if (!overlay || !content) return;
+
+        function open(src, kind, name) {
+          content.innerHTML = "";
+          downloadLink.href = src;
+          if (kind === "image") {
+            const img = document.createElement("img");
+            img.src = src;
+            img.alt = name || "";
+            img.className = "max-h-[90vh] max-w-[90vw] object-contain rounded";
+            content.appendChild(img);
+          } else if (kind === "video") {
+            const video = document.createElement("video");
+            video.src = src;
+            video.controls = true;
+            video.autoplay = true;
+            video.className = "max-h-[90vh] max-w-[90vw] rounded";
+            content.appendChild(video);
+          }
+          overlay.classList.remove("hidden");
+          overlay.classList.add("flex");
+          document.body.classList.add("overflow-hidden");
+        }
+
+        function close() {
+          overlay.classList.add("hidden");
+          overlay.classList.remove("flex");
+          document.body.classList.remove("overflow-hidden");
+          content.innerHTML = "";
+        }
+
+        closeBtn?.addEventListener("click", close);
+        overlay.addEventListener("click", (e) => {
+          if (e.target === overlay) close();
+        });
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape" && !overlay.classList.contains("hidden")) close();
+        });
+
+        document.addEventListener("click", (e) => {
+          const el = e.target.closest("[data-lightbox]");
+          if (!el) return;
+          e.preventDefault();
+          e.stopPropagation();
+          open(el.dataset.lightbox, el.dataset.lightboxKind, el.dataset.lightboxName);
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -104,7 +104,7 @@
 
     <div id="lightbox-overlay" class="fixed inset-0 z-[100] hidden items-center justify-center bg-black/80 p-4" role="dialog" aria-modal="true">
       <button type="button" id="lightbox-close" class="absolute right-4 top-4 z-10 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white hover:bg-black/70" aria-label="閉じる">✕</button>
-      <a id="lightbox-download" href="#" target="_blank" rel="noopener noreferrer" class="absolute left-4 top-4 z-10 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white hover:bg-black/70">ダウンロード</a>
+      <a id="lightbox-download" href="#" class="absolute left-4 top-4 z-10 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white hover:bg-black/70">ダウンロード</a>
       <div id="lightbox-content" class="flex max-h-full max-w-full items-center justify-center"></div>
     </div>
     <script>
@@ -128,7 +128,6 @@
             const video = document.createElement("video");
             video.src = src;
             video.controls = true;
-            video.autoplay = true;
             video.className = "max-h-[90vh] max-w-[90vw] rounded";
             content.appendChild(video);
           }

--- a/templates/form_public.html
+++ b/templates/form_public.html
@@ -175,7 +175,7 @@
                       {% elif display_item.type in ["enum", "master"] %}
                         {% set di_fw = "max-w-sm" %}
                       {% endif %}
-                      <div data-role="master-display-row" data-master-display-key="{{ display_item.key }}" class="hidden py-1 lg:py-1.5">
+                      <div data-role="master-display-row" data-master-display-key="{{ display_item.key }}" data-master-display-type="{{ display_item.type }}" class="hidden py-1 lg:py-1.5">
                         <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">
                           <div class="lg:col-span-3">
                             <div class="block text-sm font-semibold leading-6">{{ display_item.label }}</div>
@@ -235,7 +235,7 @@
               {% elif display_item.type in ["enum", "master"] %}
                 {% set di_fw = "max-w-sm" %}
               {% endif %}
-              <div data-role="master-display-row" data-master-display-key="{{ display_item.key }}" class="hidden py-1 lg:py-1.5">
+              <div data-role="master-display-row" data-master-display-key="{{ display_item.key }}" data-master-display-type="{{ display_item.type }}" class="hidden py-1 lg:py-1.5">
                 <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">
                   <div class="lg:col-span-3">
                     <div class="block text-sm font-semibold leading-6">{{ display_item.label }}</div>
@@ -360,7 +360,18 @@
 
 </style>
 
+<script id="sf-file-infos" type="application/json">{{ file_infos | default({}) | tojson }}</script>
+
 <script>
+  const SF_FILE_INFOS = (() => {
+    try {
+      const el = document.getElementById("sf-file-infos");
+      return el ? JSON.parse(el.textContent || "{}") : {};
+    } catch (_) {
+      return {};
+    }
+  })();
+
   function preventSubmitOnEnter(form) {
     if (!form) return;
     let allowSubmitByButton = false;
@@ -555,11 +566,75 @@
     return "";
   }
 
-  function renderMasterDisplayValue(valueEl, rawValue) {
+  function renderMasterFileEntry(container, fileId) {
+    const info = SF_FILE_INFOS[fileId] || null;
+    const name = info?.name || fileId;
+    const kind = info?.kind || "";
+    const href = `/files/${encodeURIComponent(fileId)}`;
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "space-y-1";
+
+    if (kind === "image") {
+      const img = document.createElement("img");
+      img.src = href;
+      img.alt = name;
+      img.loading = "lazy";
+      img.className = "max-h-40 max-w-xs rounded border border-slate-200 object-contain cursor-pointer";
+      img.dataset.lightbox = href;
+      img.dataset.lightboxKind = "image";
+      img.dataset.lightboxName = name;
+      wrapper.appendChild(img);
+    } else if (kind === "video") {
+      const thumb = document.createElement("div");
+      thumb.className = "max-h-48 max-w-sm flex items-center justify-center bg-slate-100 rounded border border-slate-200 cursor-pointer h-32 w-48";
+      thumb.dataset.lightbox = href;
+      thumb.dataset.lightboxKind = "video";
+      thumb.dataset.lightboxName = name;
+      thumb.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-slate-400" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>';
+      wrapper.appendChild(thumb);
+    } else if (kind === "audio") {
+      const audio = document.createElement("audio");
+      audio.src = href;
+      audio.controls = true;
+      audio.preload = "metadata";
+      audio.className = "w-full max-w-xs";
+      wrapper.appendChild(audio);
+    }
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.className = "block break-all text-xs text-slate-500 underline";
+    link.textContent = name;
+    wrapper.appendChild(link);
+
+    container.appendChild(wrapper);
+  }
+
+  function renderMasterFileValue(valueEl, rawValue) {
+    const ids = String(rawValue ?? "")
+      .split(",")
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0);
+    if (ids.length === 0) return;
+    const wrap = document.createElement("div");
+    wrap.className = "flex flex-wrap gap-2";
+    ids.forEach((id) => renderMasterFileEntry(wrap, id));
+    valueEl.appendChild(wrap);
+  }
+
+  function renderMasterDisplayValue(valueEl, rawValue, type) {
     if (!valueEl) return;
     valueEl.replaceChildren();
     const value = String(rawValue ?? "").trim();
     if (!value) return;
+
+    if (type === "file") {
+      renderMasterFileValue(valueEl, value);
+      return;
+    }
 
     const parts = value
       .split(/,\s+/)
@@ -602,9 +677,10 @@
     let visibleCount = 0;
     rows.forEach((row) => {
       const key = row.dataset.masterDisplayKey || "";
+      const type = row.dataset.masterDisplayType || "";
       const value = String(displayMap[key] ?? "").trim();
       const valueEl = row.querySelector("[data-role='master-display-value']");
-      renderMasterDisplayValue(valueEl, value);
+      renderMasterDisplayValue(valueEl, value, type);
       const show = value.length > 0;
       row.classList.toggle("hidden", !show);
       if (show) {

--- a/templates/submission_edit.html
+++ b/templates/submission_edit.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_file_preview.html" import file_value as render_file_value %}
 {% block content %}
 
 {% macro get_value(data, key) %}{{ data.get(key, "") if data else "" }}{% endmacro %}
@@ -149,6 +150,7 @@
             <div class="mt-1 w-full {{ ns.fw }} lg:mt-0">
               {% if arr_values %}
               <div class="mb-2 text-xs text-slate-500">現在のファイル: {{ arr_values | length }}件 (新しいファイルを選択すると置き換えます)</div>
+              <div class="mb-2">{{ render_file_value(arr_values, file_infos) }}</div>
               {% endif %}
               <input type="file" name="{{ form_name }}" multiple class="w-full rounded border border-slate-300 px-2 py-2" {% if file_accept %}accept="{{ file_accept }}"{% endif %} />
             </div>
@@ -245,6 +247,7 @@
           <div class="mt-1 w-full {{ ns.fw }} lg:mt-0">
             {% if current_value %}
             <div class="mb-2 text-xs text-slate-500">現在のファイルあり (新しいファイルを選択すると置き換えます)</div>
+            <div class="mb-2">{{ render_file_value(current_value, file_infos) }}</div>
             {% endif %}
             <input type="file" name="{{ form_name }}" class="w-full rounded border border-slate-300 px-2 py-2" {% if file_accept %}accept="{{ file_accept }}"{% endif %} />
           </div>

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_file_preview.html" import file_value as render_file_value %}
 {% block content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
   <div>
@@ -159,7 +160,16 @@
         </td>
         {% for value in row["values"] %}
         {% set column = display_columns[loop.index0] %}
-        {% if column.kind == "default"
+        {% set raw_value = row.raw_values[loop.index0] if row.raw_values is defined else none %}
+        {% if column.kind == "default" and column.field.type == "file" and raw_value %}
+          <td class="px-4 py-3">
+            {{ render_file_value(raw_value, file_infos, "sm") }}
+          </td>
+        {% elif column.kind == "master_display" and column.display_type == "file" and raw_value %}
+          <td class="px-4 py-3">
+            {{ render_file_value(raw_value, file_infos, "sm") }}
+          </td>
+        {% elif column.kind == "default"
               and column.field.type == "string"
               and (
                 column.field.format == "url"

--- a/templates/user_submissions.html
+++ b/templates/user_submissions.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_file_preview.html" import file_value as render_file_value %}
 {% block content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
   <div>
@@ -164,7 +165,16 @@
         </td>
         {% for value in row["values"] %}
         {% set column = display_columns[loop.index0] %}
-        {% if column.kind == "default"
+        {% set raw_value = row.raw_values[loop.index0] if row.raw_values is defined else none %}
+        {% if column.kind == "default" and column.field.type == "file" and raw_value %}
+          <td class="px-4 py-3">
+            {{ render_file_value(raw_value, file_infos, "sm") }}
+          </td>
+        {% elif column.kind == "master_display" and column.display_type == "file" and raw_value %}
+          <td class="px-4 py-3">
+            {{ render_file_value(raw_value, file_infos, "sm") }}
+          </td>
+        {% elif column.kind == "default"
               and column.field.type == "string"
               and (
                 column.field.format == "url"


### PR DESCRIPTION
## Summary

- ファイルフィールド（画像・動画・音声）の中身を送信一覧・編集画面・参照フィールドで確認できるようにした
- 画像と動画はクリックで全画面ライトボックス（90vw × 90vh）を開き、`Esc` / 背景クリック / ✕ ボタンで閉じる
- 参照フィールドの表示項目でも file 型を選択できるようにし、入力ページの参照先表示でもプレビューを描画

## 変更点

### サーバー側
- `file_formats.py`: MIME / 拡張子からブラウザ再生可能なメディア種別を返す `media_kind_for_file` を追加
- `filters.py`: ファイル ID から `{name, content_type, kind}` を解決する `resolve_file_infos` を追加
- `master.py`:
  - 参照フィールドの表示候補から file 型を除外していた制限を撤廃
  - `collect_master_display_file_ids` で参照先の file ID を収集
- `routes/submissions.py` / `routes/user.py` / `routes/public.py`: 送信一覧・編集・公開フォームの各ルートで `file_infos` をテンプレートへ受け渡し

### テンプレート
- `_file_preview.html` (新規): 画像/動画/音声/汎用ファイルを描画するマクロ集
- `base.html`: 全画面ライトボックスのモーダルとクリックハンドラを追加
- `submissions.html` / `user_submissions.html` / `submission_edit.html`: 既存の file 値にプレビュー描画を差し込み
- `form_public.html`: 参照フィールドの表示項目にクライアント側ファイルプレビュー描画処理を追加、`data-master-display-type` で型を JS に伝搬

## Test plan

- [ ] 画像・動画・音声・PDFの4種類をアップロードし、各ファイルが送信一覧でプレビュー表示される
- [ ] 画像をクリックするとライトボックスが開き、`Esc` / 背景 / ✕ で閉じる
- [ ] 動画のサムネイルをクリックするとライトボックスで再生できる
- [ ] ネストされたグループ / 配列ファイル / 参照フィールドそれぞれでプレビューが動作する
- [ ] 編集画面で既存ファイルがプレビュー表示される
- [ ] ブラウザで表示不能な種別（PDF等）はリンクのみ表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)