### PR TITLE
フォーム作成権限ユーザーの権限を整理 (#21)

### DIFF
--- a/src/schemaform/app.py
+++ b/src/schemaform/app.py
@@ -155,6 +155,14 @@ def can_view_form(request: Request, form: dict | None) -> bool:
         return False
     if can_edit_form(request, form):
         return True
+    return can_input_form(request, form)
+
+
+def can_input_form(request: Request, form: dict | None) -> bool:
+    """フォームの公開範囲設定に基づいて、入力（送信）可否を返す。
+    編集権限の有無は考慮しない。"""
+    if not form:
+        return False
     settings: Settings | None = getattr(request.app.state, "settings", None)
     if settings is None:
         return False
@@ -279,6 +287,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     templates.env.globals["can_create_form"] = can_create_form
     templates.env.globals["can_edit_form"] = can_edit_form
     templates.env.globals["can_view_form"] = can_view_form
+    templates.env.globals["can_input_form"] = can_input_form
     templates.env.globals["get_user_form_creator_group_ids"] = (
         get_user_form_creator_group_ids
     )

--- a/src/schemaform/app.py
+++ b/src/schemaform/app.py
@@ -169,9 +169,12 @@ def can_input_form(request: Request, form: dict | None) -> bool:
     if settings.solo:
         return True
     publish_ids = form.get("publish_group_ids") or []
-    if not publish_ids:
-        return True
+    allow_anonymous = bool(form.get("allow_anonymous", False))
     user = getattr(request.state, "current_user", None)
+    if not publish_ids:
+        if allow_anonymous:
+            return True
+        return user is not None
     if user is None:
         return False
     user_group_ids = {g.get("id") for g in (user.get("groups") or [])}

--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -197,9 +197,16 @@ async def home(request: Request) -> HTMLResponse:
 
 @router.get("/admin/forms", response_class=HTMLResponse, tags=["admin"])
 async def list_forms(request: Request, _: Any = Depends(form_creator_guard)) -> HTMLResponse:
+    from schemaform.app import can_edit_form
+
     storage = request.app.state.storage
     templates = request.app.state.templates
     forms = storage.forms.list_forms()
+
+    current_user = getattr(request.state, "current_user", None)
+    is_admin = bool(current_user and current_user.get("is_admin"))
+    if not is_admin:
+        forms = [f for f in forms if can_edit_form(request, f)]
 
     sort = request.query_params.get("sort", "name")
     order = request.query_params.get("order", "asc")

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -45,6 +45,21 @@ async def admin_guard(request: Request) -> None:
     await request.app.state.auth_provider.require_admin(request)
 
 
+async def form_editor_guard(request: Request, form_id: str) -> None:
+    """フォームの作成グループに所属するユーザー（または管理者）を許可する。"""
+    from schemaform.app import can_edit_form
+
+    await request.app.state.auth_provider.require_login(request)
+    storage = request.app.state.storage
+    form = storage.forms.get_form(form_id)
+    if not form:
+        raise HTTPException(status_code=404, detail="フォームが見つかりません")
+    if not can_edit_form(request, form):
+        raise HTTPException(
+            status_code=403, detail="このフォームを管理する権限がありません"
+        )
+
+
 def build_submission_display_columns(
     storage: Any, fields: list[dict[str, Any]]
 ) -> tuple[list[dict[str, Any]], dict[str, dict[str, dict[str, Any]]]]:
@@ -339,7 +354,7 @@ def collect_submission_master_display_file_ids(
     "/admin/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["admin"]
 )
 async def list_submissions(
-    request: Request, form_id: str, _: Any = Depends(admin_guard)
+    request: Request, form_id: str, _: Any = Depends(form_editor_guard)
 ) -> HTMLResponse:
     storage = request.app.state.storage
     templates = request.app.state.templates
@@ -463,7 +478,7 @@ async def list_submissions(
     "/admin/forms/{form_id}/submissions/{submission_id}/delete", tags=["admin"]
 )
 async def delete_submission(
-    request: Request, form_id: str, submission_id: str, _: Any = Depends(admin_guard)
+    request: Request, form_id: str, submission_id: str, _: Any = Depends(form_editor_guard)
 ) -> RedirectResponse:
     storage = request.app.state.storage
     form = storage.forms.get_form(form_id)
@@ -490,7 +505,7 @@ async def delete_submission(
     tags=["admin"],
 )
 async def edit_submission(
-    request: Request, form_id: str, submission_id: str, _: Any = Depends(admin_guard)
+    request: Request, form_id: str, submission_id: str, _: Any = Depends(form_editor_guard)
 ) -> HTMLResponse:
     storage = request.app.state.storage
     templates = request.app.state.templates
@@ -523,7 +538,7 @@ async def edit_submission(
     tags=["admin"],
 )
 async def update_submission(
-    request: Request, form_id: str, submission_id: str, _: Any = Depends(admin_guard)
+    request: Request, form_id: str, submission_id: str, _: Any = Depends(form_editor_guard)
 ) -> HTMLResponse:
     from jsonschema import Draft7Validator
 
@@ -708,7 +723,7 @@ async def update_submission(
 
 @router.get("/admin/forms/{form_id}/export", tags=["admin"])
 async def export_submissions(
-    request: Request, form_id: str, _: Any = Depends(admin_guard)
+    request: Request, form_id: str, _: Any = Depends(form_editor_guard)
 ) -> PlainTextResponse:
     storage = request.app.state.storage
     form = storage.forms.get_form(form_id)
@@ -857,7 +872,7 @@ def _convert_cell_value(raw: str, field: dict[str, Any]) -> Any:
     "/admin/forms/{form_id}/import", tags=["admin"]
 )
 async def import_submissions(
-    request: Request, form_id: str, _: Any = Depends(admin_guard)
+    request: Request, form_id: str, _: Any = Depends(form_editor_guard)
 ) -> RedirectResponse:
     from jsonschema import Draft7Validator
 

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -53,7 +53,7 @@ def _check_submission_editable(
 
 @router.get("/forms", tags=["user"], response_model=None)
 async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
-    from schemaform.app import can_input_form
+    from schemaform.app import can_edit_form, can_input_form
 
     current_user = getattr(request.state, "current_user", None)
     if current_user and current_user.get("is_admin"):
@@ -65,7 +65,10 @@ async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
     active_forms = [
         f
         for f in forms
-        if f.get("status") == "active" and can_input_form(request, f)
+        if (
+            (f.get("status") == "active" and can_input_form(request, f))
+            or can_edit_form(request, f)
+        )
     ]
 
     sort = request.query_params.get("sort", "name")

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -53,7 +53,7 @@ def _check_submission_editable(
 
 @router.get("/forms", tags=["user"], response_model=None)
 async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
-    from schemaform.app import can_view_form
+    from schemaform.app import can_input_form
 
     current_user = getattr(request.state, "current_user", None)
     if current_user and current_user.get("is_admin"):
@@ -65,7 +65,7 @@ async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
     active_forms = [
         f
         for f in forms
-        if f.get("status") == "active" and can_view_form(request, f)
+        if f.get("status") == "active" and can_input_form(request, f)
     ]
 
     sort = request.query_params.get("sort", "name")

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -53,12 +53,10 @@ def _check_submission_editable(
 
 @router.get("/forms", tags=["user"], response_model=None)
 async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
-    from schemaform.app import can_create_form, can_view_form
+    from schemaform.app import can_view_form
 
     current_user = getattr(request.state, "current_user", None)
-    if current_user and (
-        current_user.get("is_admin") or can_create_form(request)
-    ):
+    if current_user and current_user.get("is_admin"):
         return RedirectResponse("/admin/forms", status_code=303)
     storage = request.app.state.storage
     templates = request.app.state.templates

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -14,6 +14,10 @@
 
 <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">
   <table class="min-w-full divide-y divide-slate-200 text-sm">
+    {% set has_any_editable = namespace(value=false) %}
+    {% for form in forms %}
+      {% if can_edit_form(request, form) %}{% set has_any_editable.value = true %}{% endif %}
+    {% endfor %}
     <thead class="bg-slate-100 text-left">
       <tr>
         <th class="px-4 py-3">
@@ -26,6 +30,9 @@
             {% endif %}
           </a>
         </th>
+        {% if has_any_editable.value %}
+        <th class="px-4 py-3">状態</th>
+        {% endif %}
         <th class="px-4 py-3">ページ遷移</th>
         <th class="px-4 py-3">
           <a href="?sort=updated_at&order={{ 'desc' if sort == 'updated_at' and order == 'asc' else 'asc' }}" class="group inline-flex items-center gap-1">
@@ -41,15 +48,41 @@
     </thead>
     <tbody class="divide-y divide-slate-200">
       {% for form in forms %}
+      {% set _editable = can_edit_form(request, form) %}
       <tr>
         <td class="px-4 py-3 font-medium">
           <div class="whitespace-nowrap text-slate-900">{{ form.name }}</div>
           <div class="max-w-md whitespace-normal break-all text-xs text-slate-500">{{ form.description }}</div>
         </td>
+        {% if has_any_editable.value %}
+        <td class="px-4 py-3">
+          {% if _editable %}
+            {% if form.status == "active" %}
+            <form method="post" action="/admin/forms/{{ form.id }}/stop?next=/forms">
+              <button type="submit" class="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-1 text-xs text-emerald-800 hover:bg-emerald-200">公開中</button>
+            </form>
+            {% else %}
+            <form method="post" action="/admin/forms/{{ form.id }}/publish?next=/forms">
+              <button type="submit" class="whitespace-nowrap rounded-full bg-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-300">停止中</button>
+            </form>
+            {% endif %}
+          {% else %}
+            {% if form.status == "active" %}
+            <span class="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-1 text-xs text-emerald-800">公開中</span>
+            {% else %}
+            <span class="whitespace-nowrap rounded-full bg-slate-200 px-2 py-1 text-xs text-slate-700">停止中</span>
+            {% endif %}
+          {% endif %}
+        </td>
+        {% endif %}
         <td class="px-4 py-3">
           <div class="flex flex-nowrap gap-2 whitespace-nowrap">
-            {% if can_edit_form(request, form) %}
-            <a href="/admin/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
+            {% if has_any_editable.value %}
+              {% if _editable %}
+              <a href="/admin/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
+              {% else %}
+              <span class="whitespace-nowrap rounded border border-slate-200 px-2 py-1 text-xs text-slate-300">編集</span>
+              {% endif %}
             {% endif %}
             <a href="/f/{{ form.public_id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">入力</a>
             <a href="/forms/{{ form.id }}/submissions" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">一覧</a>
@@ -61,7 +94,7 @@
       </tr>
       {% else %}
       <tr>
-        <td colspan="3" class="px-4 py-6 text-center text-slate-500">公開中のフォームがありません。</td>
+        <td colspan="{{ 4 if has_any_editable.value else 3 }}" class="px-4 py-6 text-center text-slate-500">公開中のフォームがありません。</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -84,7 +84,11 @@
               <span class="whitespace-nowrap rounded border border-slate-200 px-2 py-1 text-xs text-slate-300">編集</span>
               {% endif %}
             {% endif %}
+            {% if can_input_form(request, form) and form.status == "active" %}
             <a href="/f/{{ form.public_id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">入力</a>
+            {% else %}
+            <span class="whitespace-nowrap rounded border border-slate-200 px-2 py-1 text-xs text-slate-300">入力</span>
+            {% endif %}
             <a href="/forms/{{ form.id }}/submissions" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">一覧</a>
           </div>
         </td>

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -5,6 +5,11 @@
     <h1 class="text-2xl font-semibold">フォーム一覧</h1>
     <p class="text-sm text-slate-600">公開中のフォームを確認できます。</p>
   </div>
+  {% if can_create_form(request) %}
+  <div class="flex items-center gap-2">
+    <a href="/admin/forms" class="rounded border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">フォーム管理</a>
+  </div>
+  {% endif %}
 </div>
 
 <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -48,6 +48,9 @@
         </td>
         <td class="px-4 py-3">
           <div class="flex flex-nowrap gap-2 whitespace-nowrap">
+            {% if can_edit_form(request, form) %}
+            <a href="/admin/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
+            {% endif %}
             <a href="/f/{{ form.public_id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">入力</a>
             <a href="/forms/{{ form.id }}/submissions" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">一覧</a>
           </div>


### PR DESCRIPTION
## 概要
[#21](https://github.com/Mokuichi147/SchemaForm/issues/21) で報告された、フォーム作成権限を持つ一般ユーザーの権限まわりの不具合を修正。

## 変更点
- `src/schemaform/routes/admin.py`: `/admin/forms` 一覧で、非管理者には `can_edit_form` が True のフォーム（自分が所属する作成グループのフォーム）のみを表示するようフィルタを追加。
- `src/schemaform/routes/submissions.py`: `form_editor_guard` を新設し、フォーム単位の管理ルート（送信一覧 / 編集 / 削除 / エクスポート / インポート）の `admin_guard` を置き換え。フォームの `creator_group_id` に所属するユーザーがアクセス可能になる。

## 解消される問題
- [x] 作成グループが関係ないフォームかつ非公開設定がフォーム一覧に表示されてしまう
- [x] 作成グループに割り当てられていても送信一覧ページを開こうとすると管理者権限が必要と表示され開けない

## テスト計画
- [ ] 一般ユーザー（フォーム作成権限グループ所属）でログインし `/admin/forms` を開き、自分のグループのフォームのみが表示されること
- [ ] 同ユーザーで送信一覧 `/admin/forms/{id}/submissions` を開けること
- [ ] 送信の編集 / 削除 / CSV エクスポート / CSV インポートが動作すること
- [ ] 関係ないフォームの `/admin/forms/{id}/submissions` を直接叩くと 403 になること
- [ ] 管理者は従来通り全フォームを閲覧・操作できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)