### PR TITLE
/admin/forms エンドポイントを /forms に統合

### DIFF
--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -155,7 +155,7 @@ def _ensure_form_editable(request: Request, form: dict | None) -> None:
         raise HTTPException(status_code=403, detail="このフォームを変更する権限がありません")
 
 
-def resolve_redirect_target(next_path: Any, default: str = "/admin/forms") -> str:
+def resolve_redirect_target(next_path: Any, default: str = "/forms") -> str:
     candidate = str(next_path or "").strip()
     if not candidate:
         return default
@@ -164,7 +164,7 @@ def resolve_redirect_target(next_path: Any, default: str = "/admin/forms") -> st
     parsed = urlsplit(candidate)
     if parsed.scheme or parsed.netloc:
         return default
-    if not parsed.path.startswith("/admin/forms"):
+    if not parsed.path.startswith("/forms"):
         return default
     if parsed.query:
         return f"{parsed.path}?{parsed.query}"
@@ -195,40 +195,7 @@ async def home(request: Request) -> HTMLResponse:
     return RedirectResponse("/forms")
 
 
-@router.get("/admin/forms", response_class=HTMLResponse, tags=["admin"])
-async def list_forms(request: Request, _: Any = Depends(form_creator_guard)) -> HTMLResponse:
-    from schemaform.app import can_edit_form
-
-    storage = request.app.state.storage
-    templates = request.app.state.templates
-    forms = storage.forms.list_forms()
-
-    current_user = getattr(request.state, "current_user", None)
-    is_admin = bool(current_user and current_user.get("is_admin"))
-    if not is_admin:
-        forms = [f for f in forms if can_edit_form(request, f)]
-
-    sort = request.query_params.get("sort", "name")
-    order = request.query_params.get("order", "asc")
-    if order not in ("asc", "desc"):
-        order = "asc"
-    reverse = order == "desc"
-
-    if sort == "updated_at":
-        forms.sort(key=lambda f: str(f.get("updated_at") or ""), reverse=reverse)
-    elif sort == "status":
-        forms.sort(key=lambda f: f.get("status") or "", reverse=reverse)
-    else:
-        sort = "name"
-        forms.sort(key=lambda f: (f.get("name") or "").lower(), reverse=reverse)
-
-    return templates.TemplateResponse(
-        "admin_forms.html",
-        {"request": request, "forms": forms, "sort": sort, "order": order},
-    )
-
-
-@router.get("/admin/forms/new", response_class=HTMLResponse, tags=["admin"])
+@router.get("/forms/new", response_class=HTMLResponse, tags=["admin"])
 async def new_form(request: Request, _: Any = Depends(form_creator_guard)) -> HTMLResponse:
     storage = request.app.state.storage
     templates = request.app.state.templates
@@ -251,7 +218,7 @@ async def new_form(request: Request, _: Any = Depends(form_creator_guard)) -> HT
     )
 
 
-@router.post("/admin/forms", response_class=HTMLResponse, tags=["admin"])
+@router.post("/forms", response_class=HTMLResponse, tags=["admin"])
 async def create_form(request: Request, _: Any = Depends(form_creator_guard)) -> HTMLResponse:
     storage = request.app.state.storage
     templates = request.app.state.templates
@@ -353,10 +320,10 @@ async def create_form(request: Request, _: Any = Depends(form_creator_guard)) ->
             "updated_at": now,
         }
     )
-    return RedirectResponse(f"/admin/forms/{form_id}", status_code=303)
+    return RedirectResponse(f"/forms/{form_id}", status_code=303)
 
 
-@router.get("/admin/forms/{form_id}", response_class=HTMLResponse, tags=["admin"])
+@router.get("/forms/{form_id}", response_class=HTMLResponse, tags=["admin"])
 async def edit_form(
     request: Request, form_id: str, _: Any = Depends(form_creator_guard)
 ) -> HTMLResponse:
@@ -388,7 +355,7 @@ async def edit_form(
     )
 
 
-@router.post("/admin/forms/{form_id}", response_class=HTMLResponse, tags=["admin"])
+@router.post("/forms/{form_id}", response_class=HTMLResponse, tags=["admin"])
 async def update_form(
     request: Request, form_id: str, _: Any = Depends(form_creator_guard)
 ) -> HTMLResponse:
@@ -491,10 +458,10 @@ async def update_form(
     if is_admin:
         updates["creator_group_id"] = creator_group_id
     updated = storage.forms.update_form(form_id, updates)
-    return RedirectResponse(f"/admin/forms/{updated['id']}", status_code=303)
+    return RedirectResponse(f"/forms/{updated['id']}", status_code=303)
 
 
-@router.post("/admin/forms/{form_id}/publish", tags=["admin"])
+@router.post("/forms/{form_id}/publish", tags=["admin"])
 async def publish_form(
     request: Request, form_id: str, _: Any = Depends(form_creator_guard)
 ) -> RedirectResponse:
@@ -506,7 +473,7 @@ async def publish_form(
     return RedirectResponse(target, status_code=303)
 
 
-@router.post("/admin/forms/{form_id}/stop", tags=["admin"])
+@router.post("/forms/{form_id}/stop", tags=["admin"])
 async def stop_form(
     request: Request, form_id: str, _: Any = Depends(form_creator_guard)
 ) -> RedirectResponse:
@@ -518,7 +485,7 @@ async def stop_form(
     return RedirectResponse(target, status_code=303)
 
 
-@router.post("/admin/forms/{form_id}/delete", tags=["admin"])
+@router.post("/forms/{form_id}/delete", tags=["admin"])
 async def delete_form(
     request: Request, form_id: str, _: Any = Depends(form_creator_guard)
 ) -> RedirectResponse:
@@ -526,4 +493,4 @@ async def delete_form(
     form = storage.forms.get_form(form_id)
     _ensure_form_editable(request, form)
     storage.forms.delete_form(form_id)
-    return RedirectResponse("/admin/forms", status_code=303)
+    return RedirectResponse("/forms", status_code=303)

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -350,20 +350,23 @@ def collect_submission_master_display_file_ids(
     return ids
 
 
-@router.get(
-    "/admin/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["admin"]
-)
-async def list_submissions(
-    request: Request, form_id: str, _: Any = Depends(form_editor_guard)
-) -> HTMLResponse:
+async def build_submission_list_context(
+    request: Request,
+    form_id: str,
+    *,
+    include_user_display_map: bool,
+    filter_user_id: int | None = None,
+) -> dict[str, Any]:
+    """共通の送信一覧コンテキストを構築する。"""
     storage = request.app.state.storage
-    templates = request.app.state.templates
     form = storage.forms.get_form(form_id)
     if not form:
         raise HTTPException(status_code=404, detail="フォームが見つかりません")
 
     fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
     submissions = storage.submissions.list_submissions(form_id)
+    if filter_user_id is not None:
+        submissions = [s for s in submissions if s.get("user_id") == filter_user_id]
     expanded_submissions: list[dict[str, Any]] = []
     for submission in submissions:
         data = submission.get("data_json", {})
@@ -384,28 +387,31 @@ async def list_submissions(
         expanded_submissions, fields, dict(request.query_params), file_names=file_names
     )
 
-    user_display_map: dict[int, str] = {}
-    auth = request.app.state.auth_provider
-    current_user = getattr(request.state, "current_user", None)
-    list_users = getattr(auth, "list_users", None)
-    if list_users is not None:
-        try:
-            users = await list_users((current_user or {}).get("token", ""))
-        except Exception:
-            users = []
-        for u in users:
-            uid = u.get("id")
-            if uid is not None:
-                user_display_map[uid] = u.get("display_name") or u.get("username") or ""
+    if include_user_display_map:
+        user_display_map: dict[int, str] = {}
+        auth = request.app.state.auth_provider
+        current_user = getattr(request.state, "current_user", None)
+        list_users = getattr(auth, "list_users", None)
+        if list_users is not None:
+            try:
+                users = await list_users((current_user or {}).get("token", ""))
+            except Exception:
+                users = []
+            for u in users:
+                uid = u.get("id")
+                if uid is not None:
+                    user_display_map[uid] = (
+                        u.get("display_name") or u.get("username") or ""
+                    )
 
-    def _resolve_user_label(item: dict[str, Any]) -> str:
-        uid = item.get("user_id")
-        if uid in user_display_map and user_display_map[uid]:
-            return user_display_map[uid]
-        return item.get("username") or ""
+        def _resolve_user_label(item: dict[str, Any]) -> str:
+            uid = item.get("user_id")
+            if uid in user_display_map and user_display_map[uid]:
+                return user_display_map[uid]
+            return item.get("username") or ""
 
-    for item in filtered:
-        item["_display_username"] = _resolve_user_label(item)
+        for item in filtered:
+            item["_display_username"] = _resolve_user_label(item)
 
     sort = request.query_params.get("sort", "created_at")
     order = request.query_params.get("order", "desc")
@@ -440,106 +446,44 @@ async def list_submissions(
         raw_values = build_submission_raw_values(
             data, display_columns, master_lookup_by_field
         )
-        display_rows.append(
-            {
-                "id": item["id"],
-                "created_at": item["created_at"],
-                "updated_at": item.get("updated_at"),
-                "username": item.get("_display_username") or "",
-                "values": row_values,
-                "raw_values": raw_values,
-            }
-        )
+        row = {
+            "id": item["id"],
+            "created_at": item["created_at"],
+            "updated_at": item.get("updated_at"),
+            "user_id": item.get("user_id"),
+            "username": (
+                item.get("_display_username")
+                if include_user_display_map
+                else item.get("username")
+            )
+            or "",
+            "values": row_values,
+            "raw_values": raw_values,
+        }
+        display_rows.append(row)
 
     total_pages = max(1, (total + page_size - 1) // page_size)
 
-    return templates.TemplateResponse(
-        "submissions.html",
-        {
-            "request": request,
-            "form": form,
-            "fields": fields,
-            "display_columns": display_columns,
-            "filter_fields": filter_fields,
-            "rows": display_rows,
-            "file_infos": file_infos,
-            "page": page,
-            "page_size": page_size,
-            "total": total,
-            "total_pages": total_pages,
-            "query": dict(request.query_params),
-            "sort": sort,
-            "order": order,
-        },
-    )
+    return {
+        "form": form,
+        "fields": fields,
+        "display_columns": display_columns,
+        "filter_fields": filter_fields,
+        "rows": display_rows,
+        "file_infos": file_infos,
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+        "total_pages": total_pages,
+        "query": dict(request.query_params),
+        "sort": sort,
+        "order": order,
+    }
 
 
-@router.post(
-    "/admin/forms/{form_id}/submissions/{submission_id}/delete", tags=["admin"]
-)
-async def delete_submission(
-    request: Request, form_id: str, submission_id: str, _: Any = Depends(form_editor_guard)
-) -> RedirectResponse:
-    storage = request.app.state.storage
-    form = storage.forms.get_form(form_id)
-    submission_data = storage.submissions.get_submission(submission_id)
-
-    storage.submissions.delete_submission(submission_id)
-
-    if (
-        form
-        and submission_data
-        and form.get("webhook_url")
-        and form.get("webhook_on_delete")
-    ):
-        from schemaform.webhook import send_webhook
-
-        await send_webhook(form["webhook_url"], "delete", form, submission_data)
-
-    return RedirectResponse(f"/admin/forms/{form_id}/submissions", status_code=303)
-
-
-@router.get(
-    "/admin/forms/{form_id}/submissions/{submission_id}/edit",
-    response_class=HTMLResponse,
-    tags=["admin"],
-)
-async def edit_submission(
-    request: Request, form_id: str, submission_id: str, _: Any = Depends(form_editor_guard)
-) -> HTMLResponse:
-    storage = request.app.state.storage
-    templates = request.app.state.templates
-    form = storage.forms.get_form(form_id)
-    if not form:
-        raise HTTPException(status_code=404, detail="フォームが見つかりません")
-    submission = storage.submissions.get_submission(submission_id)
-    if not submission or submission["form_id"] != form_id:
-        raise HTTPException(status_code=404, detail="送信データが見つかりません")
-    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
-    enrich_master_options(storage, fields)
-    file_ids = collect_file_ids([submission], fields)
-    file_infos = resolve_file_infos(storage.files, file_ids)
-    return templates.TemplateResponse(
-        "submission_edit.html",
-        {
-            "request": request,
-            "form": form,
-            "fields": fields,
-            "submission": submission,
-            "file_infos": file_infos,
-            "errors": [],
-        },
-    )
-
-
-@router.post(
-    "/admin/forms/{form_id}/submissions/{submission_id}/edit",
-    response_class=HTMLResponse,
-    tags=["admin"],
-)
-async def update_submission(
-    request: Request, form_id: str, submission_id: str, _: Any = Depends(form_editor_guard)
-) -> HTMLResponse:
+async def perform_update_submission(
+    request: Request, form_id: str, submission_id: str
+) -> HTMLResponse | RedirectResponse:
     from jsonschema import Draft7Validator
 
     from schemaform.routes.public import save_upload
@@ -718,10 +662,10 @@ async def update_submission(
 
         await send_webhook(form["webhook_url"], "edit", form, updated)
 
-    return RedirectResponse(f"/admin/forms/{form_id}/submissions", status_code=303)
+    return RedirectResponse(f"/forms/{form_id}/submissions", status_code=303)
 
 
-@router.get("/admin/forms/{form_id}/export", tags=["admin"])
+@router.get("/forms/{form_id}/export", tags=["admin"])
 async def export_submissions(
     request: Request, form_id: str, _: Any = Depends(form_editor_guard)
 ) -> PlainTextResponse:
@@ -869,7 +813,7 @@ def _convert_cell_value(raw: str, field: dict[str, Any]) -> Any:
 
 
 @router.post(
-    "/admin/forms/{form_id}/import", tags=["admin"]
+    "/forms/{form_id}/import", tags=["admin"]
 )
 async def import_submissions(
     request: Request, form_id: str, _: Any = Depends(form_editor_guard)
@@ -959,7 +903,7 @@ async def import_submissions(
         )
         imported_count += 1
 
-    return RedirectResponse(f"/admin/forms/{form_id}/submissions", status_code=303)
+    return RedirectResponse(f"/forms/{form_id}/submissions", status_code=303)
 
 
 @router.get("/healthz", tags=["system"])

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -50,7 +50,7 @@ def _check_submission_editable(
 
 @router.get("/forms", tags=["user"], response_model=None)
 async def list_forms(request: Request) -> HTMLResponse:
-    from schemaform.app import can_create_form, can_edit_form, can_input_form
+    from schemaform.app import can_edit_form, can_input_form
 
     storage = request.app.state.storage
     templates = request.app.state.templates
@@ -58,10 +58,9 @@ async def list_forms(request: Request) -> HTMLResponse:
 
     current_user = getattr(request.state, "current_user", None)
     is_admin = bool(current_user and current_user.get("is_admin"))
-    is_manager_view = is_admin or can_create_form(request)
 
-    if is_manager_view:
-        visible_forms = forms if is_admin else [f for f in forms if can_edit_form(request, f)]
+    if is_admin:
+        visible_forms = list(forms)
     else:
         visible_forms = [
             f
@@ -82,7 +81,7 @@ async def list_forms(request: Request) -> HTMLResponse:
         visible_forms.sort(
             key=lambda f: str(f.get("updated_at") or ""), reverse=reverse
         )
-    elif sort == "status" and is_manager_view:
+    elif sort == "status" and is_admin:
         visible_forms.sort(key=lambda f: f.get("status") or "", reverse=reverse)
     else:
         sort = "name"
@@ -90,7 +89,7 @@ async def list_forms(request: Request) -> HTMLResponse:
             key=lambda f: (f.get("name") or "").lower(), reverse=reverse
         )
 
-    template_name = "admin_forms.html" if is_manager_view else "forms.html"
+    template_name = "admin_forms.html" if is_admin else "forms.html"
     return templates.TemplateResponse(
         template_name,
         {

--- a/src/schemaform/routes/user.py
+++ b/src/schemaform/routes/user.py
@@ -5,21 +5,10 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from schemaform.fields import (
-    expand_group_array_rows,
-    flatten_filter_fields,
-)
-from schemaform.filters import (
-    apply_filters,
-    collect_file_ids,
-    resolve_file_infos,
-)
+from schemaform.filters import collect_file_ids, resolve_file_infos
 from schemaform.routes.submissions import (
-    build_submission_display_columns,
-    build_submission_raw_values,
-    build_submission_row_values,
-    collect_submission_master_display_file_ids,
-    sort_submissions,
+    build_submission_list_context,
+    perform_update_submission,
 )
 from schemaform.schema import fields_from_schema
 
@@ -27,12 +16,17 @@ router = APIRouter()
 
 
 def _check_submission_owner(
-    submission: dict[str, Any], current_user: dict[str, Any] | None
+    request: Any,
+    form: dict[str, Any] | None,
+    submission: dict[str, Any],
+    current_user: dict[str, Any] | None,
 ) -> None:
-    """本人の送信でなければ 403。管理者は許可。"""
+    """本人の送信、またはフォームを管理できるユーザーでなければ 403。"""
+    from schemaform.app import can_edit_form
+
     if current_user is None:
         raise HTTPException(status_code=401, detail="ログインが必要です")
-    if current_user.get("is_admin"):
+    if can_edit_form(request, form):
         return
     owner_id = submission.get("user_id")
     if owner_id is None or owner_id != current_user.get("id"):
@@ -40,10 +34,13 @@ def _check_submission_owner(
 
 
 def _check_submission_editable(
-    form: dict[str, Any], current_user: dict[str, Any] | None
+    request: Any, form: dict[str, Any], current_user: dict[str, Any] | None
 ) -> None:
-    """フォームの設定で送信内容変更が無効化されている場合は 403。管理者は許可。"""
-    if current_user and current_user.get("is_admin"):
+    """フォームの設定で送信内容変更が無効化されている場合は 403。
+    フォームを管理できるユーザーは許可。"""
+    from schemaform.app import can_edit_form
+
+    if can_edit_form(request, form):
         return
     if form.get("disallow_edit_submissions", False):
         raise HTTPException(
@@ -52,24 +49,28 @@ def _check_submission_editable(
 
 
 @router.get("/forms", tags=["user"], response_model=None)
-async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
-    from schemaform.app import can_edit_form, can_input_form
+async def list_forms(request: Request) -> HTMLResponse:
+    from schemaform.app import can_create_form, can_edit_form, can_input_form
 
-    current_user = getattr(request.state, "current_user", None)
-    if current_user and current_user.get("is_admin"):
-        return RedirectResponse("/admin/forms", status_code=303)
     storage = request.app.state.storage
     templates = request.app.state.templates
     forms = storage.forms.list_forms()
 
-    active_forms = [
-        f
-        for f in forms
-        if (
-            (f.get("status") == "active" and can_input_form(request, f))
-            or can_edit_form(request, f)
-        )
-    ]
+    current_user = getattr(request.state, "current_user", None)
+    is_admin = bool(current_user and current_user.get("is_admin"))
+    is_manager_view = is_admin or can_create_form(request)
+
+    if is_manager_view:
+        visible_forms = forms if is_admin else [f for f in forms if can_edit_form(request, f)]
+    else:
+        visible_forms = [
+            f
+            for f in forms
+            if (
+                (f.get("status") == "active" and can_input_form(request, f))
+                or can_edit_form(request, f)
+            )
+        ]
 
     sort = request.query_params.get("sort", "name")
     order = request.query_params.get("order", "asc")
@@ -78,18 +79,23 @@ async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
     reverse = order == "desc"
 
     if sort == "updated_at":
-        active_forms.sort(
+        visible_forms.sort(
             key=lambda f: str(f.get("updated_at") or ""), reverse=reverse
         )
+    elif sort == "status" and is_manager_view:
+        visible_forms.sort(key=lambda f: f.get("status") or "", reverse=reverse)
     else:
         sort = "name"
-        active_forms.sort(key=lambda f: (f.get("name") or "").lower(), reverse=reverse)
+        visible_forms.sort(
+            key=lambda f: (f.get("name") or "").lower(), reverse=reverse
+        )
 
+    template_name = "admin_forms.html" if is_manager_view else "forms.html"
     return templates.TemplateResponse(
-        "forms.html",
+        template_name,
         {
             "request": request,
-            "forms": active_forms,
+            "forms": visible_forms,
             "sort": sort,
             "order": order,
         },
@@ -100,131 +106,55 @@ async def list_forms(request: Request) -> HTMLResponse | RedirectResponse:
     "/forms/{form_id}/submissions", response_class=HTMLResponse, tags=["user"]
 )
 async def list_submissions(request: Request, form_id: str) -> HTMLResponse:
+    from schemaform.app import can_edit_form, can_view_form
+
     storage = request.app.state.storage
     templates = request.app.state.templates
-    from schemaform.app import can_view_form
 
     form = storage.forms.get_form(form_id)
     if not form:
         raise HTTPException(status_code=404, detail="フォームが見つかりません")
 
     current_user = getattr(request.state, "current_user", None)
-    is_admin = bool(current_user and current_user.get("is_admin"))
     publish_ids = form.get("publish_group_ids") or []
     if publish_ids and current_user is None:
         await request.app.state.auth_provider.require_login(request)
     if not can_view_form(request, form):
         raise HTTPException(status_code=403, detail="このフォームを閲覧する権限がありません")
-    if not form.get("allow_view_others", True) and not is_admin:
+    is_manager_view = can_edit_form(request, form)
+    if not form.get("allow_view_others", True) and not is_manager_view:
         await request.app.state.auth_provider.require_login(request)
 
-    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
-    submissions = storage.submissions.list_submissions(form_id)
-    if not is_admin and not form.get("allow_view_others", True):
-        user_id = current_user.get("id") if current_user else None
-        submissions = [s for s in submissions if s.get("user_id") == user_id]
-    expanded_submissions: list[dict[str, Any]] = []
-    for submission in submissions:
-        data = submission.get("data_json", {})
-        for expanded_data in expand_group_array_rows(fields, data):
-            expanded_submissions.append({**submission, "data_json": expanded_data})
-    file_ids = collect_file_ids(submissions, fields)
+    filter_user_id: int | None = None
+    if not is_manager_view and not form.get("allow_view_others", True):
+        filter_user_id = current_user.get("id") if current_user else None
 
-    display_columns, master_lookup_by_field = build_submission_display_columns(
-        storage, fields
-    )
-    file_ids |= collect_submission_master_display_file_ids(
-        submissions, display_columns, master_lookup_by_field
-    )
-    file_infos = resolve_file_infos(storage.files, file_ids)
-    file_names = {fid: info["name"] for fid, info in file_infos.items()}
-
-    filtered = apply_filters(
-        expanded_submissions,
-        fields,
-        dict(request.query_params),
-        file_names=file_names,
+    context = await build_submission_list_context(
+        request,
+        form_id,
+        include_user_display_map=is_manager_view,
+        filter_user_id=filter_user_id,
     )
 
-    sort = request.query_params.get("sort", "created_at")
-    order = request.query_params.get("order", "desc")
-    sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
-
-    try:
-        page = int(request.query_params.get("page", 1))
-    except (ValueError, TypeError):
-        page = 1
-    try:
-        page_size = int(request.query_params.get("page_size", 50))
-    except (ValueError, TypeError):
-        page_size = 50
-    page = max(1, page)
-    page_size = max(1, min(page_size, 100))
-    total = len(filtered)
-    start = (page - 1) * page_size
-    end = start + page_size
-    page_items = filtered[start:end]
-
-    filter_fields = flatten_filter_fields(fields)
-
-    display_rows = []
-    for item in page_items:
-        data = item.get("data_json", {})
-        row_values = build_submission_row_values(
-            data,
-            display_columns,
-            master_lookup_by_field,
-            file_names,
-        )
-        raw_values = build_submission_raw_values(
-            data, display_columns, master_lookup_by_field
-        )
-        display_rows.append(
-            {
-                "id": item["id"],
-                "created_at": item["created_at"],
-                "updated_at": item.get("updated_at"),
-                "user_id": item.get("user_id"),
-                "username": item.get("username"),
-                "values": row_values,
-                "raw_values": raw_values,
-            }
-        )
-
-    total_pages = max(1, (total + page_size - 1) // page_size)
-
-    allow_edit = not form.get("disallow_edit_submissions", False)
-    for row in display_rows:
-        owner_id = row.get("user_id")
-        if current_user is None:
-            row["editable"] = False
-        elif current_user.get("is_admin"):
-            row["editable"] = True
-        elif not allow_edit:
-            row["editable"] = False
-        else:
-            row["editable"] = (
-                owner_id is not None and owner_id == current_user.get("id")
-            )
+    if is_manager_view:
+        template_name = "submissions.html"
+    else:
+        template_name = "user_submissions.html"
+        allow_edit = not form.get("disallow_edit_submissions", False)
+        for row in context["rows"]:
+            owner_id = row.get("user_id")
+            if current_user is None:
+                row["editable"] = False
+            elif not allow_edit:
+                row["editable"] = False
+            else:
+                row["editable"] = (
+                    owner_id is not None and owner_id == current_user.get("id")
+                )
 
     return templates.TemplateResponse(
-        "user_submissions.html",
-        {
-            "request": request,
-            "form": form,
-            "fields": fields,
-            "display_columns": display_columns,
-            "filter_fields": filter_fields,
-            "rows": display_rows,
-            "file_infos": file_infos,
-            "page": page,
-            "page_size": page_size,
-            "total": total,
-            "total_pages": total_pages,
-            "query": dict(request.query_params),
-            "sort": sort,
-            "order": order,
-        },
+        template_name,
+        {"request": request, **context},
     )
 
 
@@ -249,8 +179,8 @@ async def edit_submission(
     if not submission or submission["form_id"] != form_id:
         raise HTTPException(status_code=404, detail="送信データが見つかりません")
 
-    _check_submission_owner(submission, current_user)
-    _check_submission_editable(form, current_user)
+    _check_submission_owner(request, form, submission, current_user)
+    _check_submission_editable(request, form, current_user)
 
     fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
     enrich_master_options(storage, fields)
@@ -280,22 +210,17 @@ async def edit_submission(
 async def update_submission(
     request: Request, form_id: str, submission_id: str
 ) -> HTMLResponse | RedirectResponse:
-    from schemaform.routes.submissions import update_submission as admin_update
-
     storage = request.app.state.storage
     current_user = getattr(request.state, "current_user", None)
     existing = storage.submissions.get_submission(submission_id)
     if not existing or existing.get("form_id") != form_id:
         raise HTTPException(status_code=404, detail="送信データが見つかりません")
     form = storage.forms.get_form(form_id)
-    _check_submission_owner(existing, current_user)
+    _check_submission_owner(request, form, existing, current_user)
     if form is not None:
-        _check_submission_editable(form, current_user)
+        _check_submission_editable(request, form, current_user)
 
-    response = await admin_update(request, form_id, submission_id, None)
-    if isinstance(response, RedirectResponse):
-        return RedirectResponse(f"/forms/{form_id}/submissions", status_code=303)
-    return response
+    return await perform_update_submission(request, form_id, submission_id)
 
 
 @router.post(
@@ -310,9 +235,9 @@ async def delete_submission(
     submission = storage.submissions.get_submission(submission_id)
     if not submission or submission.get("form_id") != form_id:
         raise HTTPException(status_code=404, detail="送信データが見つかりません")
-    _check_submission_owner(submission, current_user)
+    _check_submission_owner(request, form, submission, current_user)
     if form is not None:
-        _check_submission_editable(form, current_user)
+        _check_submission_editable(request, form, current_user)
 
     storage.submissions.delete_submission(submission_id)
 

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -8,16 +8,16 @@
   {% if form %}
   <div class="flex flex-wrap gap-2 text-sm">
     {% if form.status == "active" %}
-    <form method="post" action="/admin/forms/{{ form.id }}/stop?next=/admin/forms/{{ form.id }}">
+    <form method="post" action="/forms/{{ form.id }}/stop?next=/forms/{{ form.id }}">
       <button type="submit" class="whitespace-nowrap rounded-full bg-emerald-100 px-3 py-1 text-emerald-800 hover:bg-emerald-200">公開中</button>
     </form>
     {% else %}
-    <form method="post" action="/admin/forms/{{ form.id }}/publish?next=/admin/forms/{{ form.id }}">
+    <form method="post" action="/forms/{{ form.id }}/publish?next=/forms/{{ form.id }}">
       <button type="submit" class="whitespace-nowrap rounded-full bg-slate-200 px-3 py-1 text-slate-700 hover:bg-slate-300">停止中</button>
     </form>
     {% endif %}
     <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-3 py-1">入力ページ</a>
-    <a href="/admin/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-3 py-1">送信一覧</a>
+    <a href="/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-3 py-1">送信一覧</a>
   </div>
   {% endif %}
 </div>
@@ -32,7 +32,7 @@
 </div>
 {% endif %}
 
-<form method="post" action="{% if form %}/admin/forms/{{ form.id }}{% else %}/admin/forms{% endif %}" class="mt-6 space-y-3">
+<form method="post" action="{% if form %}/forms/{{ form.id }}{% else %}/forms{% endif %}" class="mt-6 space-y-3">
   {% set _u = get_current_user(request) %}
   {% set _is_admin = _u and _u.is_admin %}
   {% set _current_group = form.creator_group_id if form else None %}
@@ -217,7 +217,7 @@
 
   <div class="flex flex-wrap gap-3">
     <button type="submit" class="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white">保存</button>
-    <a href="/admin/forms" class="rounded border border-slate-300 px-4 py-2 text-sm">戻る</a>
+    <a href="/forms" class="rounded border border-slate-300 px-4 py-2 text-sm">戻る</a>
   </div>
 </form>
 

--- a/templates/admin_forms.html
+++ b/templates/admin_forms.html
@@ -10,7 +10,7 @@
     {% if get_auth_enabled(request) and _u and _u.is_admin %}
     <a href="/admin/groups" class="rounded border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">グループ管理</a>
     {% endif %}
-    <a href="/admin/forms/new" class="rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white">新規フォーム</a>
+    <a href="/forms/new" class="rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white">新規フォーム</a>
   </div>
 </div>
 
@@ -63,11 +63,11 @@
         <td class="px-4 py-3">
           {% if _editable %}
             {% if form.status == "active" %}
-            <form method="post" action="/admin/forms/{{ form.id }}/stop">
+            <form method="post" action="/forms/{{ form.id }}/stop">
               <button type="submit" class="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-1 text-xs text-emerald-800 hover:bg-emerald-200">公開中</button>
             </form>
             {% else %}
-            <form method="post" action="/admin/forms/{{ form.id }}/publish">
+            <form method="post" action="/forms/{{ form.id }}/publish">
               <button type="submit" class="whitespace-nowrap rounded-full bg-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-300">停止中</button>
             </form>
             {% endif %}
@@ -82,12 +82,12 @@
         <td class="px-4 py-3">
           <div class="flex flex-nowrap gap-2 whitespace-nowrap">
             {% if _editable %}
-            <a href="/admin/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
+            <a href="/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
             {% else %}
             <span class="whitespace-nowrap rounded border border-slate-200 px-2 py-1 text-xs text-slate-300">編集</span>
             {% endif %}
             <a href="/f/{{ form.public_id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">入力</a>
-            <a href="/admin/forms/{{ form.id }}/submissions" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">一覧</a>
+            <a href="/forms/{{ form.id }}/submissions" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">一覧</a>
           </div>
         </td>
         <td class="px-4 py-3 text-slate-600">
@@ -95,7 +95,7 @@
         </td>
         <td class="px-4 py-3">
           {% if _editable %}
-          <form method="post" action="/admin/forms/{{ form.id }}/delete" onsubmit="return confirm('このフォームを削除しますか？')">
+          <form method="post" action="/forms/{{ form.id }}/delete" onsubmit="return confirm('このフォームを削除しますか？')">
             <button class="whitespace-nowrap rounded border border-rose-300 px-2 py-1 text-xs text-rose-600">削除</button>
           </form>
           {% else %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,9 +85,7 @@
       <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
         {% set auth_enabled = get_auth_enabled(request) %}
         {% set current_user = get_current_user(request) %}
-        {% set is_admin_view = (not auth_enabled) or (current_user and current_user.is_admin) %}
-        {% set is_manager_view = is_admin_view or can_create_form(request) %}
-        <a href="{{ '/admin/forms' if is_manager_view else '/forms' }}" class="text-lg font-semibold">SchemaForm</a>
+        <a href="/forms" class="text-lg font-semibold">SchemaForm</a>
         <nav class="flex items-center gap-3 text-sm text-slate-600">
           {% if auth_enabled %}
             {% if current_user %}

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -5,11 +5,6 @@
     <h1 class="text-2xl font-semibold">フォーム一覧</h1>
     <p class="text-sm text-slate-600">公開中のフォームを確認できます。</p>
   </div>
-  {% if can_create_form(request) %}
-  <div class="flex items-center gap-2">
-    <a href="/admin/forms" class="rounded border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">フォーム管理</a>
-  </div>
-  {% endif %}
 </div>
 
 <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">
@@ -58,11 +53,11 @@
         <td class="px-4 py-3">
           {% if _editable %}
             {% if form.status == "active" %}
-            <form method="post" action="/admin/forms/{{ form.id }}/stop?next=/forms">
+            <form method="post" action="/forms/{{ form.id }}/stop?next=/forms">
               <button type="submit" class="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-1 text-xs text-emerald-800 hover:bg-emerald-200">公開中</button>
             </form>
             {% else %}
-            <form method="post" action="/admin/forms/{{ form.id }}/publish?next=/forms">
+            <form method="post" action="/forms/{{ form.id }}/publish?next=/forms">
               <button type="submit" class="whitespace-nowrap rounded-full bg-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-300">停止中</button>
             </form>
             {% endif %}
@@ -79,7 +74,7 @@
           <div class="flex flex-nowrap gap-2 whitespace-nowrap">
             {% if has_any_editable.value %}
               {% if _editable %}
-              <a href="/admin/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
+              <a href="/forms/{{ form.id }}" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs">編集</a>
               {% else %}
               <span class="whitespace-nowrap rounded border border-slate-200 px-2 py-1 text-xs text-slate-300">編集</span>
               {% endif %}

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -5,6 +5,11 @@
     <h1 class="text-2xl font-semibold">フォーム一覧</h1>
     <p class="text-sm text-slate-600">公開中のフォームを確認できます。</p>
   </div>
+  {% if can_create_form(request) %}
+  <div class="flex items-center gap-2">
+    <a href="/forms/new" class="rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white">新規フォーム</a>
+  </div>
+  {% endif %}
 </div>
 
 <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 bg-white">

--- a/templates/submission_edit.html
+++ b/templates/submission_edit.html
@@ -10,7 +10,7 @@
       <h1 class="text-2xl font-semibold">送信データ編集</h1>
       <p class="text-sm text-slate-600">{{ form.name }} の送信データを編集します。</p>
     </div>
-    <a href="{{ cancel_url or "/admin/forms/" ~ form.id ~ "/submissions" }}" class="rounded border border-slate-300 px-3 py-2 text-sm">送信一覧に戻る</a>
+    <a href="{{ cancel_url or "/forms/" ~ form.id ~ "/submissions" }}" class="rounded border border-slate-300 px-3 py-2 text-sm">送信一覧に戻る</a>
   </div>
 
   {% if errors %}
@@ -31,7 +31,7 @@
 
     <div class="flex gap-3">
       <button type="submit" class="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white">保存</button>
-      <a href="{{ cancel_url or "/admin/forms/" ~ form.id ~ "/submissions" }}" class="rounded border border-slate-300 px-4 py-2 text-sm">キャンセル</a>
+      <a href="{{ cancel_url or "/forms/" ~ form.id ~ "/submissions" }}" class="rounded border border-slate-300 px-4 py-2 text-sm">キャンセル</a>
     </div>
   </form>
 </div>

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -8,13 +8,13 @@
   </div>
   <div class="flex gap-2">
     <button type="button" id="open-filter-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">フィルター</button>
-    <form id="import-form" method="post" action="/admin/forms/{{ form.id }}/import" enctype="multipart/form-data" class="inline">
+    <form id="import-form" method="post" action="/forms/{{ form.id }}/import" enctype="multipart/form-data" class="inline">
       <input type="file" id="import-file-input" name="file" accept=".csv,.tsv" required class="hidden" />
       <button type="button" id="open-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">取り込み</button>
     </form>
     <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-3 py-2 text-sm">入力ページ</a>
-    <a href="/admin/forms/{{ form.id }}/export?{{ build_query(query, format='csv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">CSV</a>
-    <a href="/admin/forms/{{ form.id }}/export?{{ build_query(query, format='tsv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">TSV</a>
+    <a href="/forms/{{ form.id }}/export?{{ build_query(query, format='csv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">CSV</a>
+    <a href="/forms/{{ form.id }}/export?{{ build_query(query, format='tsv', page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">TSV</a>
   </div>
 </div>
 
@@ -98,7 +98,7 @@
 
       <div class="mt-4 flex gap-2 border-t border-slate-200 pt-4">
         <button type="submit" class="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white">検索</button>
-        <a href="/admin/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-3 py-2 text-sm">リセット</a>
+        <a href="/forms/{{ form.id }}/submissions" class="rounded border border-slate-300 px-3 py-2 text-sm">リセット</a>
         <button type="button" data-action="close-filter-modal" class="ml-auto rounded border border-slate-300 px-3 py-2 text-sm">閉じる</button>
       </div>
     </form>
@@ -211,8 +211,8 @@
         {% endfor %}
         <td class="px-4 py-3">
           <div class="flex gap-1">
-            <a href="/admin/forms/{{ form.id }}/submissions/{{ row.id }}/edit" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs text-slate-700">編集</a>
-            <form method="post" action="/admin/forms/{{ form.id }}/submissions/{{ row.id }}/delete">
+            <a href="/forms/{{ form.id }}/submissions/{{ row.id }}/edit" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs text-slate-700">編集</a>
+            <form method="post" action="/forms/{{ form.id }}/submissions/{{ row.id }}/delete">
               <button class="whitespace-nowrap rounded border border-rose-300 px-2 py-1 text-xs text-rose-600">削除</button>
             </form>
           </div>


### PR DESCRIPTION
管理者向けと利用者向けで重複していた /admin/forms と /forms のルートを
/forms に一本化し、テンプレート選択と権限チェックを呼び出し側で行うよう統一。

- admin.py: フォームCRUDのパスを /admin/forms から /forms に変更し、
  リダイレクト先と redirect_target の検証も /forms 基準に揃える
- submissions.py: 一覧/編集/削除のルートを削除し、user.py が再利用できる
  共通関数 (build_submission_list_context / perform_update_submission) に
  整理。export/import のパスも /forms 配下へ移動
- user.py: 管理者を /admin/forms にリダイレクトする処理を廃止し、
  権限に応じて admin_forms.html / forms.html、submissions.html /
  user_submissions.html を切り替えて描画
- テンプレート群: /admin/forms 参照を /forms に置換し、base.html の
  ナビゲーションも /forms に統一