### PR TITLE
ユーザー向けUIからライブラリ名 user-permission の露出を除去

### DIFF
--- a/src/schemaform/cli.py
+++ b/src/schemaform/cli.py
@@ -33,13 +33,13 @@ def main(
     port: int | None = typer.Option(None, help="バインドするポート"),
     user_permission_db: str | None = typer.Option(
         None,
-        "--user-permission-db",
-        help="user-permission の DBパス or URL",
+        "--auth-db",
+        help="認証DBのパス or URL",
     ),
     user_permission_secret: str | None = typer.Option(
         None,
-        "--user-permission-secret",
-        help="user-permission のシークレットキーファイルのパス（ローカルDB使用時）",
+        "--auth-secret",
+        help="シークレットキーファイルのパス（ローカルDB使用時）",
     ),
     solo: bool = typer.Option(
         False,
@@ -71,13 +71,13 @@ def run(
     port: int | None = typer.Option(None, help="バインドするポート"),
     user_permission_db: str | None = typer.Option(
         None,
-        "--user-permission-db",
-        help="user-permission の DBパス or URL",
+        "--auth-db",
+        help="認証DBのパス or URL",
     ),
     user_permission_secret: str | None = typer.Option(
         None,
-        "--user-permission-secret",
-        help="user-permission のシークレットキーファイルのパス（ローカルDB使用時）",
+        "--auth-secret",
+        help="シークレットキーファイルのパス（ローカルDB使用時）",
     ),
     solo: bool = typer.Option(
         False,
@@ -131,10 +131,10 @@ def create_admin(
         None, help="管理者グループ名（省略時は Settings の値）"
     ),
     user_permission_db: str | None = typer.Option(
-        None, "--user-permission-db", help="user-permission の DBパス or URL"
+        None, "--auth-db", help="認証DBのパス or URL"
     ),
     user_permission_secret: str | None = typer.Option(
-        None, "--user-permission-secret", help="シークレットキーファイルのパス"
+        None, "--auth-secret", help="シークレットキーファイルのパス"
     ),
 ) -> None:
     """管理者ユーザーを作成し、管理者グループへ追加する。"""

--- a/templates/admin_groups.html
+++ b/templates/admin_groups.html
@@ -3,7 +3,7 @@
 <div class="flex flex-wrap items-center justify-between gap-3">
   <div>
     <h1 class="text-2xl font-semibold">グループ管理</h1>
-    <p class="text-sm text-slate-600">user-permission のグループを管理します。</p>
+    <p class="text-sm text-slate-600">グループを管理します。</p>
   </div>
 </div>
 


### PR DESCRIPTION
- templates/admin_groups.html の説明文からライブラリ名を削除
- CLI オプション名を --user-permission-db/--user-permission-secret から
  --auth-db/--auth-secret に変更し、ヘルプ文のライブラリ名も削除

https://claude.ai/code/session_014B1d6biWjzX3mV7hhxnJcf