### PR TITLE
作成グループを複数選択可の編集グループへ変更

### DIFF
--- a/src/schemaform/app.py
+++ b/src/schemaform/app.py
@@ -141,11 +141,11 @@ def can_edit_form(request: Request, form: dict | None) -> bool:
         return True
     if not form:
         return False
-    creator_group_id = form.get("creator_group_id")
-    if creator_group_id is None:
+    edit_group_ids = form.get("edit_group_ids") or []
+    if not edit_group_ids:
         return False
     user_group_ids = {g.get("id") for g in (user.get("groups") or [])}
-    return creator_group_id in user_group_ids
+    return bool(set(edit_group_ids) & user_group_ids)
 
 
 def can_view_form(request: Request, form: dict | None) -> bool:

--- a/src/schemaform/models.py
+++ b/src/schemaform/models.py
@@ -22,7 +22,7 @@ class FormModel(Base):
     webhook_on_submit = Column(Integer, default=0)
     webhook_on_delete = Column(Integer, default=0)
     webhook_on_edit = Column(Integer, default=0)
-    creator_group_id = Column(Integer, nullable=True, index=True)
+    edit_group_ids = Column(Text, nullable=True)
     publish_group_ids = Column(Text, nullable=True)
     allow_view_others = Column(Integer, default=0)
     disallow_edit_submissions = Column(Integer, default=0)

--- a/src/schemaform/repo_json.py
+++ b/src/schemaform/repo_json.py
@@ -97,7 +97,7 @@ class JSONFormRepo(JSONRepoBase):
         for key, value in form.items():
             if key in {"created_at", "updated_at"}:
                 record[key] = to_iso(value) if isinstance(value, datetime) else value
-            elif key == "publish_group_ids":
+            elif key in {"publish_group_ids", "edit_group_ids"}:
                 record[key] = _normalize_group_ids(value)
             else:
                 record[key] = value
@@ -120,7 +120,14 @@ class JSONFormRepo(JSONRepoBase):
             "webhook_on_submit": record.get("webhook_on_submit", False),
             "webhook_on_delete": record.get("webhook_on_delete", False),
             "webhook_on_edit": record.get("webhook_on_edit", False),
-            "creator_group_id": record.get("creator_group_id"),
+            "edit_group_ids": _normalize_group_ids(
+                record.get("edit_group_ids")
+                or (
+                    [record["creator_group_id"]]
+                    if record.get("creator_group_id") is not None
+                    else []
+                )
+            ),
             "publish_group_ids": _normalize_group_ids(
                 record.get("publish_group_ids")
             ),

--- a/src/schemaform/repo_sqlite.py
+++ b/src/schemaform/repo_sqlite.py
@@ -64,7 +64,9 @@ class SQLiteFormRepo:
                 webhook_on_submit=1 if form.get("webhook_on_submit") else 0,
                 webhook_on_delete=1 if form.get("webhook_on_delete") else 0,
                 webhook_on_edit=1 if form.get("webhook_on_edit") else 0,
-                creator_group_id=form.get("creator_group_id"),
+                edit_group_ids=dumps_json(
+                    _normalize_group_ids(form.get("edit_group_ids"))
+                ),
                 publish_group_ids=dumps_json(
                     _normalize_group_ids(form.get("publish_group_ids"))
                 ),
@@ -96,7 +98,7 @@ class SQLiteFormRepo:
                     "allow_anonymous",
                 }:
                     setattr(row, key, 1 if value else 0)
-                elif key == "publish_group_ids":
+                elif key in {"publish_group_ids", "edit_group_ids"}:
                     setattr(row, key, dumps_json(_normalize_group_ids(value)))
                 else:
                     setattr(row, key, value)
@@ -134,7 +136,9 @@ class SQLiteFormRepo:
             "webhook_on_submit": bool(row.webhook_on_submit),
             "webhook_on_delete": bool(row.webhook_on_delete),
             "webhook_on_edit": bool(row.webhook_on_edit),
-            "creator_group_id": row.creator_group_id,
+            "edit_group_ids": _normalize_group_ids(
+                loads_json(row.edit_group_ids) if row.edit_group_ids else []
+            ),
             "publish_group_ids": _normalize_group_ids(
                 loads_json(row.publish_group_ids) if row.publish_group_ids else []
             ),
@@ -320,14 +324,29 @@ class SQLiteStorage:
                         "ALTER TABLE forms ADD COLUMN webhook_on_edit INTEGER DEFAULT 0"
                     )
                 )
-            if "creator_group_id" not in form_columns:
-                conn.execute(
-                    text("ALTER TABLE forms ADD COLUMN creator_group_id INTEGER")
-                )
             if "publish_group_ids" not in form_columns:
                 conn.execute(
                     text("ALTER TABLE forms ADD COLUMN publish_group_ids TEXT")
                 )
+            if "edit_group_ids" not in form_columns:
+                conn.execute(
+                    text("ALTER TABLE forms ADD COLUMN edit_group_ids TEXT")
+                )
+                if "creator_group_id" in form_columns:
+                    conn.execute(
+                        text(
+                            "UPDATE forms SET edit_group_ids = "
+                            "'[' || creator_group_id || ']' "
+                            "WHERE creator_group_id IS NOT NULL "
+                            "AND (edit_group_ids IS NULL OR edit_group_ids = '')"
+                        )
+                    )
+                    try:
+                        conn.execute(
+                            text("ALTER TABLE forms DROP COLUMN creator_group_id")
+                        )
+                    except Exception:
+                        pass
             if "allow_view_others" not in form_columns:
                 conn.execute(
                     text(

--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -94,7 +94,7 @@ def _parse_edit_group_ids(
         try:
             gid = int(s)
         except ValueError:
-            errors.append("編集グループの指定が不正です")
+            errors.append("編集範囲の指定が不正です")
             continue
         if gid in seen:
             continue
@@ -103,7 +103,7 @@ def _parse_edit_group_ids(
         seen.add(gid)
         result.append(gid)
     if not result and not is_admin:
-        errors.append("編集グループを選択してください")
+        errors.append("編集範囲のグループを選択してください")
     return sorted(result), errors
 
 
@@ -417,7 +417,7 @@ async def update_form(
     )
     edit_group_ids = sorted(set(parsed_edit_ids) | preserved_ids)
     if not is_admin and not edit_group_ids:
-        edit_errors.append("編集グループを選択してください")
+        edit_errors.append("編集範囲のグループを選択してください")
     errors.extend(edit_errors)
 
     def _render(form_extra: dict[str, Any] | None = None) -> HTMLResponse:

--- a/src/schemaform/routes/admin.py
+++ b/src/schemaform/routes/admin.py
@@ -81,6 +81,32 @@ async def _list_all_groups(request: Request) -> list[dict[str, Any]]:
     return _normalize_group_options(groups)
 
 
+def _parse_edit_group_ids(
+    raw_values: list[str], allowed_ids: set[int], is_admin: bool
+) -> tuple[list[int], list[str]]:
+    errors: list[str] = []
+    result: list[int] = []
+    seen: set[int] = set()
+    for raw in raw_values:
+        s = str(raw or "").strip()
+        if not s:
+            continue
+        try:
+            gid = int(s)
+        except ValueError:
+            errors.append("編集グループの指定が不正です")
+            continue
+        if gid in seen:
+            continue
+        if allowed_ids and gid not in allowed_ids:
+            continue
+        seen.add(gid)
+        result.append(gid)
+    if not result and not is_admin:
+        errors.append("編集グループを選択してください")
+    return sorted(result), errors
+
+
 def _parse_publish_group_ids(
     publish_scope: str, raw_values: list[str], all_group_ids: set[int]
 ) -> tuple[list[int], bool, list[str]]:
@@ -226,7 +252,6 @@ async def create_form(request: Request, _: Any = Depends(form_creator_guard)) ->
     name = str(form_data.get("name", "")).strip()
     description = str(form_data.get("description", "")).strip()
     fields_json = str(form_data.get("fields_json", ""))
-    creator_group_raw = str(form_data.get("creator_group_id", "")).strip()
 
     fields, errors = parse_fields_json(fields_json)
     master_forms, master_field_catalog = build_master_field_catalog(storage)
@@ -244,27 +269,21 @@ async def create_form(request: Request, _: Any = Depends(form_creator_guard)) ->
     user = getattr(request.state, "current_user", None)
     is_admin = bool(user and user.get("is_admin"))
     available_ids = {g["id"] for g in available_groups}
-    creator_group_id: int | None = None
-    if creator_group_raw:
-        try:
-            creator_group_id = int(creator_group_raw)
-        except ValueError:
-            errors.append("作成グループの指定が不正です")
-        else:
-            if creator_group_id not in available_ids:
-                errors.append("選択したグループにフォームを作成する権限がありません")
-    if not is_admin and creator_group_id is None:
-        if len(available_ids) == 1:
-            creator_group_id = next(iter(available_ids))
-        else:
-            errors.append("作成グループを選択してください")
+    raw_edit_ids = form_data.getlist("edit_group_ids")
+    if not is_admin and not any(str(v or "").strip() for v in raw_edit_ids) and len(available_ids) == 1:
+        edit_group_ids = [next(iter(available_ids))]
+        edit_errors: list[str] = []
+    else:
+        edit_group_ids, edit_errors = _parse_edit_group_ids(
+            raw_edit_ids, available_ids, is_admin
+        )
+    errors.extend(edit_errors)
 
     def _render(form_extra: dict[str, Any] | None = None) -> HTMLResponse:
         base = {"name": name, "description": description}
         if form_extra:
             base.update(form_extra)
-        if creator_group_id is not None:
-            base["creator_group_id"] = creator_group_id
+        base["edit_group_ids"] = edit_group_ids
         base["publish_group_ids"] = publish_group_ids
         base["allow_anonymous"] = allow_anonymous
         return templates.TemplateResponse(
@@ -311,7 +330,7 @@ async def create_form(request: Request, _: Any = Depends(form_creator_guard)) ->
             "webhook_on_submit": webhook_on_submit,
             "webhook_on_delete": webhook_on_delete,
             "webhook_on_edit": webhook_on_edit,
-            "creator_group_id": creator_group_id,
+            "edit_group_ids": edit_group_ids,
             "publish_group_ids": publish_group_ids,
             "allow_view_others": allow_view_others,
             "disallow_edit_submissions": disallow_edit_submissions,
@@ -388,26 +407,22 @@ async def update_form(
 
     user = getattr(request.state, "current_user", None)
     is_admin = bool(user and user.get("is_admin"))
-    creator_group_id: int | None = form.get("creator_group_id")
-    if is_admin:
-        raw = str(form_data.get("creator_group_id", "")).strip()
-        if raw == "":
-            creator_group_id = None
-        else:
-            try:
-                new_id = int(raw)
-            except ValueError:
-                errors.append("作成グループの指定が不正です")
-            else:
-                allowed_ids = {g["id"] for g in available_groups}
-                if new_id not in allowed_ids:
-                    errors.append("選択したグループは利用できません")
-                else:
-                    creator_group_id = new_id
+    available_ids = {g["id"] for g in available_groups}
+    existing_edit_ids: list[int] = list(form.get("edit_group_ids") or [])
+    preserved_ids: set[int] = (
+        set() if is_admin else {gid for gid in existing_edit_ids if gid not in available_ids}
+    )
+    parsed_edit_ids, edit_errors = _parse_edit_group_ids(
+        form_data.getlist("edit_group_ids"), available_ids, is_admin=True
+    )
+    edit_group_ids = sorted(set(parsed_edit_ids) | preserved_ids)
+    if not is_admin and not edit_group_ids:
+        edit_errors.append("編集グループを選択してください")
+    errors.extend(edit_errors)
 
     def _render(form_extra: dict[str, Any] | None = None) -> HTMLResponse:
         base = {**form, "name": name, "description": description}
-        base["creator_group_id"] = creator_group_id
+        base["edit_group_ids"] = edit_group_ids
         base["publish_group_ids"] = publish_group_ids
         base["allow_anonymous"] = allow_anonymous
         if form_extra:
@@ -453,10 +468,9 @@ async def update_form(
         "disallow_edit_submissions": disallow_edit_submissions,
         "allow_anonymous": allow_anonymous,
         "publish_group_ids": publish_group_ids,
+        "edit_group_ids": edit_group_ids,
         "updated_at": now_utc(),
     }
-    if is_admin:
-        updates["creator_group_id"] = creator_group_id
     updated = storage.forms.update_form(form_id, updates)
     return RedirectResponse(f"/forms/{updated['id']}", status_code=303)
 

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -35,7 +35,7 @@
 <form method="post" action="{% if form %}/forms/{{ form.id }}{% else %}/forms{% endif %}" class="mt-6 space-y-3">
   {% set _u = get_current_user(request) %}
   {% set _is_admin = _u and _u.is_admin %}
-  {% set _current_group = form.creator_group_id if form else None %}
+  {% set _edit_ids = (form.edit_group_ids if form and form.edit_group_ids is defined else []) or [] %}
   {% set _publish_ids = (form.publish_group_ids if form and form.publish_group_ids is defined else []) or [] %}
   {% set _publish_scope = 'public' if (form and form.allow_anonymous) else ('groups' if _publish_ids else 'authenticated') %}
 
@@ -64,41 +64,42 @@
     </div>
   </div>
 
-  {% if available_groups %}
   <div class="py-2 lg:py-3">
     <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">
       <div class="lg:col-span-3">
         <label class="block text-sm font-semibold leading-6">
-          作成グループ
-          {% if not _is_admin and available_groups | length > 1 %}<span class="text-rose-500">*</span>{% endif %}
+          編集グループ
+          {% if not _is_admin %}<span class="text-rose-500">*</span>{% endif %}
         </label>
-        <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">紐付けたグループのメンバーのみがこのフォームを編集できます。</div>
+        <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">選択したグループのメンバーがこのフォームを編集できます。空にすると管理者のみ編集可能です。</div>
       </div>
       <div class="sf-field-input-col lg:col-span-9">
-        {% if _is_admin %}
-        <select name="creator_group_id" class="mt-1 w-full max-w-sm rounded border border-slate-300 px-2 py-2 text-sm lg:mt-0">
-          <option value="">なし（管理者のみ編集可能）</option>
-          {% for g in available_groups %}
-          <option value="{{ g.id }}" {% if _current_group == g.id %}selected{% endif %}>{{ g.name }}</option>
-          {% endfor %}
-        </select>
-        {% else %}
-          {% if available_groups | length == 1 %}
-          <input type="hidden" name="creator_group_id" value="{{ available_groups[0].id }}" />
-          <div class="mt-1 w-full max-w-sm rounded-md bg-slate-100/70 px-3 py-2 text-sm leading-relaxed text-slate-700 lg:mt-0">{{ available_groups[0].name }}</div>
+        <div class="mt-1 w-full max-w-md rounded border border-slate-200 bg-slate-50 px-3 py-2 lg:mt-0">
+          {% if available_groups %}
+          <div class="array-field w-full" data-key="edit_group_ids" data-type="enum" data-picker="" data-unique="1" data-initial="{{ _edit_ids | tojson_attr }}">
+            <div class="space-y-2 array-items"></div>
+            <button type="button" class="add-item mt-1 rounded border border-slate-300 bg-white px-3 py-1 text-xs">追加</button>
+            <template>
+              <div class="flex items-start gap-2 array-item">
+                <div class="w-full space-y-1">
+                  <select name="edit_group_ids" data-choice-select="1" data-search-placeholder="グループを検索" class="w-full rounded border border-slate-300 bg-white px-2 py-2 text-sm">
+                    <option value="">選択してください</option>
+                    {% for g in available_groups %}
+                    <option value="{{ g.id }}">{{ g.name }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <button type="button" class="remove-item shrink-0 whitespace-nowrap rounded border border-rose-300 bg-white px-2 py-1 text-xs text-rose-600">削除</button>
+              </div>
+            </template>
+          </div>
           {% else %}
-          <select name="creator_group_id" required class="mt-1 w-full max-w-sm rounded border border-slate-300 px-2 py-2 text-sm lg:mt-0">
-            <option value="">選択してください</option>
-            {% for g in available_groups %}
-            <option value="{{ g.id }}" {% if _current_group == g.id %}selected{% endif %}>{{ g.name }}</option>
-            {% endfor %}
-          </select>
+          <div class="text-sm text-slate-500">選択できるグループがありません。</div>
           {% endif %}
-        {% endif %}
+        </div>
       </div>
     </div>
   </div>
-  {% endif %}
 
   <div class="py-2 lg:py-3">
     <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -74,29 +74,27 @@
         <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">選択したグループのメンバーがこのフォームを編集できます。</div>
       </div>
       <div class="sf-field-input-col lg:col-span-9">
-        <div class="mt-1 w-full max-w-md rounded border border-slate-200 bg-slate-50 px-3 py-2 lg:mt-0">
-          {% if available_groups %}
-          <div class="array-field w-full" data-key="edit_group_ids" data-type="enum" data-picker="" data-unique="1" data-initial="{{ _edit_ids | tojson_attr }}">
-            <div class="space-y-2 array-items"></div>
-            <button type="button" class="add-item mt-1 rounded border border-slate-300 bg-white px-3 py-1 text-xs">追加</button>
-            <template>
-              <div class="flex items-start gap-2 array-item">
-                <div class="w-full space-y-1">
-                  <select name="edit_group_ids" data-choice-select="1" data-search-placeholder="グループを検索" class="w-full rounded border border-slate-300 bg-white px-2 py-2 text-sm">
-                    <option value="">選択してください</option>
-                    {% for g in available_groups %}
-                    <option value="{{ g.id }}">{{ g.name }}</option>
-                    {% endfor %}
-                  </select>
-                </div>
-                <button type="button" class="remove-item shrink-0 whitespace-nowrap rounded border border-rose-300 bg-white px-2 py-1 text-xs text-rose-600">削除</button>
+        {% if available_groups %}
+        <div class="array-field mt-1 w-full max-w-md lg:mt-0" data-key="edit_group_ids" data-type="enum" data-picker="" data-unique="1" data-initial="{{ _edit_ids | tojson_attr }}">
+          <div class="space-y-2 array-items"></div>
+          <button type="button" class="add-item mt-1 rounded border border-slate-300 bg-white px-3 py-1 text-xs">追加</button>
+          <template>
+            <div class="flex items-start gap-2 array-item">
+              <div class="w-full space-y-1">
+                <select name="edit_group_ids" data-choice-select="1" data-search-placeholder="グループを検索" class="w-full rounded border border-slate-300 bg-white px-2 py-2 text-sm">
+                  <option value="">選択してください</option>
+                  {% for g in available_groups %}
+                  <option value="{{ g.id }}">{{ g.name }}</option>
+                  {% endfor %}
+                </select>
               </div>
-            </template>
-          </div>
-          {% else %}
-          <div class="text-sm text-slate-500">選択できるグループがありません。</div>
-          {% endif %}
+              <button type="button" class="remove-item shrink-0 whitespace-nowrap rounded border border-rose-300 bg-white px-2 py-1 text-xs text-rose-600">削除</button>
+            </div>
+          </template>
         </div>
+        {% else %}
+        <div class="mt-1 text-sm text-slate-500 lg:mt-0">選択できるグループがありません。</div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -68,7 +68,7 @@
     <div class="sf-field-row lg:grid lg:grid-cols-12 lg:items-start lg:gap-4">
       <div class="lg:col-span-3">
         <label class="block text-sm font-semibold leading-6">
-          編集グループ
+          編集範囲
           {% if not _is_admin %}<span class="text-rose-500">*</span>{% endif %}
         </label>
         <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">選択したグループのメンバーがこのフォームを編集できます。空にすると管理者のみ編集可能です。</div>

--- a/templates/admin_form_builder.html
+++ b/templates/admin_form_builder.html
@@ -71,7 +71,7 @@
           編集範囲
           {% if not _is_admin %}<span class="text-rose-500">*</span>{% endif %}
         </label>
-        <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">選択したグループのメンバーがこのフォームを編集できます。空にすると管理者のみ編集可能です。</div>
+        <div class="mt-0.5 break-words text-xs leading-relaxed text-slate-500">選択したグループのメンバーがこのフォームを編集できます。</div>
       </div>
       <div class="sf-field-input-col lg:col-span-9">
         <div class="mt-1 w-full max-w-md rounded border border-slate-200 bg-slate-50 px-3 py-2 lg:mt-0">


### PR DESCRIPTION
公開範囲 (publish_group_ids) と同じ array-field + data-unique="1"
パターンで、フォーム作成権限を持つグループから複数選択 (重複NG) で
編集者を指定できるよう仕様変更。空のときは管理者のみ編集可能。