### PR TITLE
Add aggregation/analytics view for form submissions

### DIFF
--- a/src/schemaform/aggregate.py
+++ b/src/schemaform/aggregate.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import Any, Iterator
+
+from schemaform.calculated import _apply_aggregate, _collect_numeric_values
+from schemaform.fields import flatten_fields, get_nested_value
+
+NUMERIC_TYPES = {"number", "integer", "calculated"}
+TRUTHY_STRINGS = {"true", "1", "yes", "on"}
+
+
+def _format_num(value: float) -> str:
+    """数値を表示用文字列に整形する（整数値は小数点なし、それ以外は小数2桁）。"""
+    rounded = round(float(value), 2)
+    if rounded == int(rounded):
+        return str(int(rounded))
+    return f"{rounded:g}"
+
+
+def _format_stat(value: float | None) -> str:
+    return "—" if value is None else _format_num(value)
+
+
+def _iter_field_values(
+    submissions: list[dict[str, Any]], flat_key: str
+) -> Iterator[Any]:
+    for submission in submissions:
+        yield get_nested_value(submission.get("data_json", {}), flat_key)
+
+
+def _distinct_submissions(
+    submissions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """配列グループ展開で重複した送信を id 単位に一意化する。"""
+    seen: set[Any] = set()
+    result: list[dict[str, Any]] = []
+    for submission in submissions:
+        sid = submission.get("id")
+        if sid in seen:
+            continue
+        seen.add(sid)
+        result.append(submission)
+    return result
+
+
+def build_histogram(
+    values: list[float], max_bins: int = 10, is_integer: bool = False
+) -> dict[str, Any]:
+    """数値リストを等幅ビンに集計する。
+
+    値が0/1個・全同値の場合は単一ビンにフォールバックしてゼロ除算を避ける。
+    整数かつレンジが狭い場合は値ごとのビンにする。
+    """
+    if not values:
+        return {"labels": [], "counts": []}
+
+    low = min(values)
+    high = max(values)
+    if low == high:
+        return {"labels": [_format_num(low)], "counts": [len(values)]}
+
+    if (
+        is_integer
+        and float(low).is_integer()
+        and float(high).is_integer()
+        and (high - low) <= max_bins - 1
+    ):
+        ilow, ihigh = int(low), int(high)
+        labels = [str(v) for v in range(ilow, ihigh + 1)]
+        counts = [0] * len(labels)
+        for value in values:
+            counts[int(round(value)) - ilow] += 1
+        return {"labels": labels, "counts": counts}
+
+    bins = max_bins
+    width = (high - low) / bins
+    edges = [low + width * i for i in range(bins + 1)]
+    counts = [0] * bins
+    for value in values:
+        index = int((value - low) / width)
+        if index >= bins:
+            index = bins - 1
+        elif index < 0:
+            index = 0
+        counts[index] += 1
+    labels = [
+        f"{_format_num(edges[i])}–{_format_num(edges[i + 1])}" for i in range(bins)
+    ]
+    return {"labels": labels, "counts": counts}
+
+
+def _distribution_enum(
+    field: dict[str, Any], submissions: list[dict[str, Any]], flat_key: str
+) -> dict[str, Any]:
+    order: list[str] = [str(v) for v in (field.get("enum") or [])]
+    counts: dict[str, int] = {label: 0 for label in order}
+    seen = set(order)
+    total = 0
+    for value in _iter_field_values(submissions, flat_key):
+        items = value if isinstance(value, list) else [value]
+        for item in items:
+            if item is None or item == "":
+                continue
+            key = str(item)
+            if key not in seen:
+                order.append(key)
+                seen.add(key)
+                counts[key] = 0
+            counts[key] += 1
+            total += 1
+    return {
+        "key": flat_key,
+        "label": field["flat_label"],
+        "kind": "distribution",
+        "is_enum": True,
+        "supports_correct": True,
+        "labels": order,
+        "counts": [counts[label] for label in order],
+        "total": total,
+    }
+
+
+def _distribution_boolean(
+    field: dict[str, Any], submissions: list[dict[str, Any]], flat_key: str
+) -> dict[str, Any]:
+    true_count = 0
+    false_count = 0
+    total = 0
+    for value in _iter_field_values(submissions, flat_key):
+        items = value if isinstance(value, list) else [value]
+        for item in items:
+            if item is None or item == "":
+                continue
+            total += 1
+            truthy = item is True or (
+                isinstance(item, str) and item.lower() in TRUTHY_STRINGS
+            )
+            if truthy:
+                true_count += 1
+            else:
+                false_count += 1
+    return {
+        "key": flat_key,
+        "label": field["flat_label"],
+        "kind": "distribution",
+        "is_enum": False,
+        "supports_correct": False,
+        "labels": ["true", "false"],
+        "counts": [true_count, false_count],
+        "total": total,
+    }
+
+
+def _numeric(
+    field: dict[str, Any], submissions: list[dict[str, Any]], flat_key: str
+) -> dict[str, Any]:
+    values: list[float] = []
+    for value in _iter_field_values(submissions, flat_key):
+        values.extend(_collect_numeric_values(value))
+    stats = {
+        "count": str(int(_apply_aggregate("count", values))),
+        "sum": _format_stat(_apply_aggregate("sum", values)),
+        "avg": _format_stat(_apply_aggregate("avg", values)),
+        "min": _format_stat(_apply_aggregate("min", values)),
+        "max": _format_stat(_apply_aggregate("max", values)),
+    }
+    histogram = build_histogram(values, is_integer=field.get("type") == "integer")
+    return {
+        "key": flat_key,
+        "label": field["flat_label"],
+        "kind": "numeric",
+        "stats": stats,
+        "histogram": histogram,
+    }
+
+
+def _to_local_date(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.astimezone().date()
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value).astimezone().date()
+        except ValueError:
+            return None
+    return None
+
+
+def _timeseries(submissions: list[dict[str, Any]]) -> dict[str, Any]:
+    """送信日時(created_at)をローカル日付で集計し、欠落日を埋めて連続化する。"""
+    day_counts: Counter[str] = Counter()
+    dates = []
+    for submission in submissions:
+        day = _to_local_date(submission.get("created_at"))
+        if day is None:
+            continue
+        day_counts[day.isoformat()] += 1
+        dates.append(day)
+    if not dates:
+        return {"labels": [], "counts": []}
+
+    labels: list[str] = []
+    counts: list[int] = []
+    current = min(dates)
+    end = max(dates)
+    while current <= end:
+        key = current.isoformat()
+        labels.append(key)
+        counts.append(day_counts.get(key, 0))
+        current = current + timedelta(days=1)
+    return {"labels": labels, "counts": counts}
+
+
+def aggregate_submissions(
+    fields: list[dict[str, Any]], submissions: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """フィールド定義と送信一覧から、表示用の集計結果を組み立てる。
+
+    submissions は配列グループ展開済み（送信一覧と同じ）を想定する。件数・時系列は
+    送信 id 単位に一意化して実際の送信数を反映する。
+    """
+    flat_fields = flatten_fields(fields, expand_rows_for_group_arrays=True)
+    aggregations: list[dict[str, Any]] = []
+    for field in flat_fields:
+        field_type = field.get("type")
+        flat_key = field["flat_key"]
+        if field_type == "enum":
+            aggregations.append(_distribution_enum(field, submissions, flat_key))
+        elif field_type == "boolean":
+            aggregations.append(_distribution_boolean(field, submissions, flat_key))
+        elif field_type in NUMERIC_TYPES:
+            aggregations.append(_numeric(field, submissions, flat_key))
+
+    distinct = _distinct_submissions(submissions)
+    return {
+        "aggregations": aggregations,
+        "timeseries": _timeseries(distinct),
+        "total_submissions": len(distinct),
+    }

--- a/src/schemaform/aggregate.py
+++ b/src/schemaform/aggregate.py
@@ -52,14 +52,22 @@ def build_histogram(
 
     値が0/1個・全同値の場合は単一ビンにフォールバックしてゼロ除算を避ける。
     整数かつレンジが狭い場合は値ごとのビンにする。
+
+    各ビンには `ranges`（[下限, 上限] の組）と `mode`（"range" は半開区間で最終ビンのみ
+    上限を含む、"exact" は値一致）を併せて返し、クリック時のドリルダウン照合に使う。
     """
     if not values:
-        return {"labels": [], "counts": []}
+        return {"labels": [], "counts": [], "ranges": [], "mode": "range"}
 
     low = min(values)
     high = max(values)
     if low == high:
-        return {"labels": [_format_num(low)], "counts": [len(values)]}
+        return {
+            "labels": [_format_num(low)],
+            "counts": [len(values)],
+            "ranges": [[low, high]],
+            "mode": "exact",
+        }
 
     if (
         is_integer
@@ -72,7 +80,8 @@ def build_histogram(
         counts = [0] * len(labels)
         for value in values:
             counts[int(round(value)) - ilow] += 1
-        return {"labels": labels, "counts": counts}
+        ranges = [[v, v] for v in range(ilow, ihigh + 1)]
+        return {"labels": labels, "counts": counts, "ranges": ranges, "mode": "exact"}
 
     bins = max_bins
     width = (high - low) / bins
@@ -88,7 +97,8 @@ def build_histogram(
     labels = [
         f"{_format_num(edges[i])}–{_format_num(edges[i + 1])}" for i in range(bins)
     ]
-    return {"labels": labels, "counts": counts}
+    ranges = [[edges[i], edges[i + 1]] for i in range(bins)]
+    return {"labels": labels, "counts": counts, "ranges": ranges, "mode": "range"}
 
 
 def _distribution_enum(

--- a/src/schemaform/aggregate.py
+++ b/src/schemaform/aggregate.py
@@ -125,6 +125,7 @@ def _distribution_enum(
         "label": field["flat_label"],
         "kind": "distribution",
         "is_enum": True,
+        "is_array": bool(field.get("is_array")),
         "supports_correct": True,
         "labels": order,
         "counts": [counts[label] for label in order],

--- a/src/schemaform/aggregate.py
+++ b/src/schemaform/aggregate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 from typing import Any, Iterator
 
 from schemaform.calculated import _apply_aggregate, _collect_numeric_values
@@ -188,40 +187,36 @@ def _numeric(
     }
 
 
-def _to_local_date(value: Any) -> Any:
+def to_utc_iso(value: Any) -> str | None:
+    """datetime/ISO文字列を UTC・秒精度の ISO 文字列にする。naive はUTCとみなす。
+
+    ブラウザ側で各自のローカル時刻に変換して粒度バケットを作るため、絶対時刻
+    （UTC）で受け渡す。送信一覧の日時表示と同じ基準。"""
     if isinstance(value, datetime):
-        return value.astimezone().date()
-    if isinstance(value, str):
+        aware = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    elif isinstance(value, str):
         try:
-            return datetime.fromisoformat(value).astimezone().date()
+            parsed = datetime.fromisoformat(value)
         except ValueError:
             return None
-    return None
+        aware = parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    else:
+        return None
+    return aware.astimezone(timezone.utc).replace(microsecond=0).isoformat()
 
 
-def _timeseries(submissions: list[dict[str, Any]]) -> dict[str, Any]:
-    """送信日時(created_at)をローカル日付で集計し、欠落日を埋めて連続化する。"""
-    day_counts: Counter[str] = Counter()
-    dates = []
+def _timeseries_timestamps(submissions: list[dict[str, Any]]) -> list[str]:
+    """件数推移グラフ用に、各送信の送信日時（UTC・秒精度のISO文字列）を返す。
+
+    横軸の粒度（秒・分・時・日・週・月・年）は、送信日時の間隔に応じてクライアント
+    側で自動選択し、手動でも切り替えられるようにする。"""
+    out: list[str] = []
     for submission in submissions:
-        day = _to_local_date(submission.get("created_at"))
-        if day is None:
-            continue
-        day_counts[day.isoformat()] += 1
-        dates.append(day)
-    if not dates:
-        return {"labels": [], "counts": []}
-
-    labels: list[str] = []
-    counts: list[int] = []
-    current = min(dates)
-    end = max(dates)
-    while current <= end:
-        key = current.isoformat()
-        labels.append(key)
-        counts.append(day_counts.get(key, 0))
-        current = current + timedelta(days=1)
-    return {"labels": labels, "counts": counts}
+        iso = to_utc_iso(submission.get("created_at"))
+        if iso is not None:
+            out.append(iso)
+    out.sort()
+    return out
 
 
 def aggregate_submissions(
@@ -247,6 +242,6 @@ def aggregate_submissions(
     distinct = _distinct_submissions(submissions)
     return {
         "aggregations": aggregations,
-        "timeseries": _timeseries(distinct),
+        "timeseries_timestamps": _timeseries_timestamps(distinct),
         "total_submissions": len(distinct),
     }

--- a/src/schemaform/aggregate.py
+++ b/src/schemaform/aggregate.py
@@ -126,6 +126,7 @@ def _distribution_enum(
         "kind": "distribution",
         "is_enum": True,
         "is_array": bool(field.get("is_array")),
+        "unique_items": bool(field.get("unique_items")),
         "supports_correct": True,
         "labels": order,
         "counts": [counts[label] for label in order],

--- a/src/schemaform/app.py
+++ b/src/schemaform/app.py
@@ -18,6 +18,7 @@ from schemaform.file_formats import file_accept_for_constraints
 from schemaform.file_signing import load_or_create_secret
 from schemaform.routes.admin import router as admin_router
 from schemaform.routes.admin_groups import router as admin_groups_router
+from schemaform.routes.aggregate import router as aggregate_router
 from schemaform.routes.api import router as api_router
 from schemaform.routes.auth import router as auth_router
 from schemaform.routes.public import router as public_router
@@ -314,6 +315,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(user_router)
     app.include_router(public_router)
     app.include_router(submissions_router)
+    app.include_router(aggregate_router)
     app.include_router(api_router)
 
     return app

--- a/src/schemaform/routes/aggregate.py
+++ b/src/schemaform/routes/aggregate.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
-from schemaform.aggregate import aggregate_submissions
+from schemaform.aggregate import NUMERIC_TYPES, aggregate_submissions
+from schemaform.fields import flatten_fields, get_nested_value
 from schemaform.routes.submissions import (
+    build_full_table_context,
     form_editor_guard,
     gather_filtered_submissions,
 )
 
 router = APIRouter()
+
+DRILL_TYPES = NUMERIC_TYPES | {"enum", "boolean"}
 
 
 @router.get("/forms/{form_id}/aggregate", response_class=HTMLResponse, tags=["user"])
@@ -23,6 +28,28 @@ async def aggregate_view(
         request, form_id
     )
     result = aggregate_submissions(fields, filtered)
+    table = build_full_table_context(request, fields, filtered)
+
+    drill_keys = [
+        field["flat_key"]
+        for field in flatten_fields(fields, expand_rows_for_group_arrays=True)
+        if field.get("type") in DRILL_TYPES
+    ]
+    for row, item in zip(table["rows"], filtered):
+        data = item.get("data_json", {})
+        drill: dict[str, Any] = {}
+        for key in drill_keys:
+            value = get_nested_value(data, key)
+            if value is not None and value != "":
+                drill[key] = value
+        row["drill"] = drill
+        created = item.get("created_at")
+        row["date"] = (
+            created.astimezone().date().isoformat()
+            if isinstance(created, datetime)
+            else ""
+        )
+
     return templates.TemplateResponse(
         "aggregate.html",
         {
@@ -30,5 +57,6 @@ async def aggregate_view(
             "form": form,
             "query": dict(request.query_params),
             **result,
+            **table,
         },
     )

--- a/src/schemaform/routes/aggregate.py
+++ b/src/schemaform/routes/aggregate.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from schemaform.aggregate import aggregate_submissions
+from schemaform.routes.submissions import (
+    form_editor_guard,
+    gather_filtered_submissions,
+)
+
+router = APIRouter()
+
+
+@router.get("/forms/{form_id}/aggregate", response_class=HTMLResponse, tags=["user"])
+async def aggregate_view(
+    request: Request, form_id: str, _: Any = Depends(form_editor_guard)
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    form, fields, filtered, _file_names = await gather_filtered_submissions(
+        request, form_id
+    )
+    result = aggregate_submissions(fields, filtered)
+    return templates.TemplateResponse(
+        "aggregate.html",
+        {
+            "request": request,
+            "form": form,
+            "query": dict(request.query_params),
+            **result,
+        },
+    )

--- a/src/schemaform/routes/aggregate.py
+++ b/src/schemaform/routes/aggregate.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
-from schemaform.aggregate import NUMERIC_TYPES, aggregate_submissions
+from schemaform.aggregate import NUMERIC_TYPES, aggregate_submissions, to_utc_iso
 from schemaform.fields import flatten_fields, get_nested_value
 from schemaform.routes.submissions import (
     build_full_table_context,
@@ -43,12 +42,7 @@ async def aggregate_view(
             if value is not None and value != "":
                 drill[key] = value
         row["drill"] = drill
-        created = item.get("created_at")
-        row["date"] = (
-            created.astimezone().date().isoformat()
-            if isinstance(created, datetime)
-            else ""
-        )
+        row["ts"] = to_utc_iso(item.get("created_at")) or ""
 
     return templates.TemplateResponse(
         "aggregate.html",

--- a/src/schemaform/routes/aggregate.py
+++ b/src/schemaform/routes/aggregate.py
@@ -28,7 +28,7 @@ async def aggregate_view(
         request, form_id
     )
     result = aggregate_submissions(fields, filtered)
-    table = build_full_table_context(request, fields, filtered)
+    table = await build_full_table_context(request, fields, filtered)
 
     drill_keys = [
         field["flat_key"]

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -398,6 +398,56 @@ async def gather_filtered_submissions(
     return form, fields, filtered, file_names
 
 
+def build_full_table_context(
+    request: Request,
+    fields: list[dict[str, Any]],
+    submissions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """ページングなしで送信一覧と同じ表示行を構築する（集計ページの元データ表示用）。
+
+    送信一覧の表示列／値整形ロジックをそのまま再利用し、与えられた送信集合を
+    すべて行に変換する。
+    """
+    storage = request.app.state.storage
+    display_columns, master_lookup_by_field = build_submission_display_columns(
+        storage, fields
+    )
+    file_ids = collect_file_ids(submissions, fields) | (
+        collect_submission_master_display_file_ids(
+            submissions, display_columns, master_lookup_by_field
+        )
+    )
+    file_infos = resolve_file_infos(storage.files, file_ids, file_url_builder(request))
+    file_names = {fid: info["name"] for fid, info in file_infos.items()}
+
+    rows: list[dict[str, Any]] = []
+    for item in submissions:
+        data = item.get("data_json", {})
+        rows.append(
+            {
+                "id": item["id"],
+                "created_at": item.get("created_at"),
+                "updated_at": item.get("updated_at"),
+                "username": item.get("username") or "",
+                "values": build_submission_row_values(
+                    data,
+                    display_columns,
+                    master_lookup_by_field,
+                    file_names,
+                    temporal_style="display",
+                ),
+                "raw_values": build_submission_raw_values(
+                    data, display_columns, master_lookup_by_field
+                ),
+            }
+        )
+    return {
+        "display_columns": display_columns,
+        "file_infos": file_infos,
+        "rows": rows,
+    }
+
+
 async def build_submission_list_context(
     request: Request,
     form_id: str,

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -1089,14 +1089,15 @@ def _row_is_correct(
 def _correctness_cells(
     data: dict[str, Any], correct_map: dict[str, dict[str, Any]]
 ) -> tuple[str, str]:
-    """1送信あたりの (正答数, 正答率) セル文字列を返す。画面表示と同じ表記。"""
+    """1送信あたりの (正答数, 正答率) セル文字列を返す。正答数は個数のみ、
+    正答率は%なしの数値。画面表示と同じ表記。"""
     total = len(correct_map)
     if total == 0:
         return "", ""
     correct = sum(
         1 for key, info in correct_map.items() if _row_is_correct(data, key, info)
     )
-    return f"{correct} / {total}", f"{round(correct / total * 100)}%"
+    return str(correct), str(round(correct / total * 100))
 
 
 @router.get("/forms/{form_id}/export", tags=["admin"])

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -364,6 +364,40 @@ def collect_submission_master_display_file_ids(
     return ids
 
 
+async def gather_filtered_submissions(
+    request: Request,
+    form_id: str,
+    *,
+    filter_user_id: int | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]], dict[str, str]]:
+    """フォーム・フィールド定義と、現在のクエリでフィルター済みの送信一覧、
+    ファイル名マップを返す。
+
+    送信一覧／エクスポート／集計で共通のデータ取得手順（list_submissions →
+    配列グループ行の展開 → apply_filters）をまとめたもの。
+    """
+    storage = request.app.state.storage
+    form = storage.forms.get_form(form_id)
+    if not form:
+        raise HTTPException(status_code=404, detail="フォームが見つかりません")
+
+    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
+    submissions = storage.submissions.list_submissions(form_id)
+    if filter_user_id is not None:
+        submissions = [s for s in submissions if s.get("user_id") == filter_user_id]
+    expanded_submissions: list[dict[str, Any]] = []
+    for submission in submissions:
+        data = submission.get("data_json", {})
+        for expanded_data in expand_group_array_rows(fields, data):
+            expanded_submissions.append({**submission, "data_json": expanded_data})
+    file_ids = collect_file_ids(submissions, fields)
+    file_names = resolve_file_names(storage.files, file_ids)
+    filtered = apply_filters(
+        expanded_submissions, fields, dict(request.query_params), file_names=file_names
+    )
+    return form, fields, filtered, file_names
+
+
 async def build_submission_list_context(
     request: Request,
     form_id: str,
@@ -949,21 +983,8 @@ async def export_submissions(
     request: Request, form_id: str, _: Any = Depends(form_editor_guard)
 ) -> Response:
     storage = request.app.state.storage
-    form = storage.forms.get_form(form_id)
-    if not form:
-        raise HTTPException(status_code=404, detail="フォームが見つかりません")
-
-    fields = fields_from_schema(form["schema_json"], form.get("field_order", []))
-    submissions = storage.submissions.list_submissions(form_id)
-    expanded_submissions: list[dict[str, Any]] = []
-    for submission in submissions:
-        data = submission.get("data_json", {})
-        for expanded_data in expand_group_array_rows(fields, data):
-            expanded_submissions.append({**submission, "data_json": expanded_data})
-    file_ids = collect_file_ids(submissions, fields)
-    file_names = resolve_file_names(storage.files, file_ids)
-    filtered = apply_filters(
-        expanded_submissions, fields, dict(request.query_params), file_names=file_names
+    form, fields, filtered, file_names = await gather_filtered_submissions(
+        request, form_id
     )
     display_columns, master_lookup_by_field = build_submission_display_columns(
         storage, fields

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -66,6 +66,32 @@ async def form_editor_guard(request: Request, form_id: str) -> None:
         )
 
 
+async def resolve_user_display_map(request: Request) -> dict[int, str]:
+    """user_id → 表示名 のマップを認証プロバイダから構築する。"""
+    user_display_map: dict[int, str] = {}
+    auth = request.app.state.auth_provider
+    current_user = getattr(request.state, "current_user", None)
+    list_users = getattr(auth, "list_users", None)
+    if list_users is None:
+        return user_display_map
+    try:
+        users = await list_users((current_user or {}).get("token", ""))
+    except Exception:
+        users = []
+    for u in users:
+        uid = u.get("id")
+        if uid is not None:
+            user_display_map[uid] = u.get("display_name") or u.get("username") or ""
+    return user_display_map
+
+
+def resolve_user_label(item: dict[str, Any], user_display_map: dict[int, str]) -> str:
+    uid = item.get("user_id")
+    if uid in user_display_map and user_display_map[uid]:
+        return user_display_map[uid]
+    return item.get("username") or ""
+
+
 def build_submission_display_columns(
     storage: Any, fields: list[dict[str, Any]]
 ) -> tuple[list[dict[str, Any]], dict[str, dict[str, dict[str, Any]]]]:
@@ -398,7 +424,7 @@ async def gather_filtered_submissions(
     return form, fields, filtered, file_names
 
 
-def build_full_table_context(
+async def build_full_table_context(
     request: Request,
     fields: list[dict[str, Any]],
     submissions: list[dict[str, Any]],
@@ -406,7 +432,7 @@ def build_full_table_context(
     """ページングなしで送信一覧と同じ表示行を構築する（集計ページの元データ表示用）。
 
     送信一覧の表示列／値整形ロジックをそのまま再利用し、与えられた送信集合を
-    すべて行に変換する。
+    すべて行に変換する。送信ユーザーは認証プロバイダの表示名へ解決する。
     """
     storage = request.app.state.storage
     display_columns, master_lookup_by_field = build_submission_display_columns(
@@ -419,6 +445,7 @@ def build_full_table_context(
     )
     file_infos = resolve_file_infos(storage.files, file_ids, file_url_builder(request))
     file_names = {fid: info["name"] for fid, info in file_infos.items()}
+    user_display_map = await resolve_user_display_map(request)
 
     rows: list[dict[str, Any]] = []
     for item in submissions:
@@ -428,7 +455,7 @@ def build_full_table_context(
                 "id": item["id"],
                 "created_at": item.get("created_at"),
                 "updated_at": item.get("updated_at"),
-                "username": item.get("username") or "",
+                "username": resolve_user_label(item, user_display_map),
                 "values": build_submission_row_values(
                     data,
                     display_columns,
@@ -486,30 +513,9 @@ async def build_submission_list_context(
     )
 
     if include_user_display_map:
-        user_display_map: dict[int, str] = {}
-        auth = request.app.state.auth_provider
-        current_user = getattr(request.state, "current_user", None)
-        list_users = getattr(auth, "list_users", None)
-        if list_users is not None:
-            try:
-                users = await list_users((current_user or {}).get("token", ""))
-            except Exception:
-                users = []
-            for u in users:
-                uid = u.get("id")
-                if uid is not None:
-                    user_display_map[uid] = (
-                        u.get("display_name") or u.get("username") or ""
-                    )
-
-        def _resolve_user_label(item: dict[str, Any]) -> str:
-            uid = item.get("user_id")
-            if uid in user_display_map and user_display_map[uid]:
-                return user_display_map[uid]
-            return item.get("username") or ""
-
+        user_display_map = await resolve_user_display_map(request)
         for item in filtered:
-            item["_display_username"] = _resolve_user_label(item)
+            item["_display_username"] = resolve_user_label(item, user_display_map)
 
     sort = request.query_params.get("sort", "created_at")
     order = request.query_params.get("order", "desc")
@@ -1040,25 +1046,9 @@ async def export_submissions(
         storage, fields
     )
 
-    user_display_map: dict[int, str] = {}
-    auth = request.app.state.auth_provider
-    current_user = getattr(request.state, "current_user", None)
-    list_users = getattr(auth, "list_users", None)
-    if list_users is not None:
-        try:
-            users = await list_users((current_user or {}).get("token", ""))
-        except Exception:
-            users = []
-        for u in users:
-            uid = u.get("id")
-            if uid is not None:
-                user_display_map[uid] = u.get("display_name") or u.get("username") or ""
-
+    user_display_map = await resolve_user_display_map(request)
     for item in filtered:
-        uid = item.get("user_id")
-        item["_display_username"] = (
-            user_display_map.get(uid) if uid in user_display_map else None
-        ) or item.get("username") or ""
+        item["_display_username"] = resolve_user_label(item, user_display_map)
 
     sort = request.query_params.get("sort", "created_at")
     order = request.query_params.get("order", "desc")

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -1108,6 +1108,12 @@ async def export_submissions(
     form, fields, filtered, file_names = await gather_filtered_submissions(
         request, form_id
     )
+    # 集計ページのグラフクリックによる絞り込み結果のみをダウンロードするため、
+    # 表示中の送信ID(ids)が指定されていればその送信に限定する。
+    ids_param = request.query_params.get("ids")
+    if ids_param is not None:
+        id_set = {token for token in ids_param.split(",") if token}
+        filtered = [s for s in filtered if s.get("id") in id_set]
     display_columns, master_lookup_by_field = build_submission_display_columns(
         storage, fields
     )

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -1034,6 +1034,71 @@ def _serialize_export(
     return output.getvalue(), "text/csv; charset=utf-8", "csv"
 
 
+def _parse_correct_map(raw: str | None) -> dict[str, dict[str, Any]]:
+    """集計ページから渡される正解指定(JSON)をパースする。
+
+    形式: {flat_key: {"mode": "single", "value": str}}
+          {flat_key: {"mode": "array", "list": [str], "ordered": bool}}
+    enumフィールドの正答数・正答率をダウンロードに含めるために使う。"""
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for key, info in parsed.items():
+        if not isinstance(info, dict):
+            continue
+        if info.get("mode") == "array":
+            values = info.get("list")
+            if isinstance(values, list) and values:
+                result[str(key)] = {
+                    "mode": "array",
+                    "list": [str(v) for v in values],
+                    "ordered": bool(info.get("ordered")),
+                }
+        else:
+            value = info.get("value")
+            if value not in (None, ""):
+                result[str(key)] = {"mode": "single", "value": str(value)}
+    return result
+
+
+def _row_is_correct(
+    data: dict[str, Any], flat_key: str, info: dict[str, Any]
+) -> bool:
+    value = get_nested_value(data, flat_key)
+    if value is None:
+        return False
+    if info["mode"] == "array":
+        actual = [str(v) for v in (value if isinstance(value, list) else [value])]
+        expected = info["list"]
+        if len(actual) != len(expected):
+            return False
+        if info.get("ordered"):
+            return actual == expected
+        return sorted(actual) == sorted(expected)
+    if isinstance(value, list):
+        return False
+    return str(value) == info["value"]
+
+
+def _correctness_cells(
+    data: dict[str, Any], correct_map: dict[str, dict[str, Any]]
+) -> tuple[str, str]:
+    """1送信あたりの (正答数, 正答率) セル文字列を返す。画面表示と同じ表記。"""
+    total = len(correct_map)
+    if total == 0:
+        return "", ""
+    correct = sum(
+        1 for key, info in correct_map.items() if _row_is_correct(data, key, info)
+    )
+    return f"{correct} / {total}", f"{round(correct / total * 100)}%"
+
+
 @router.get("/forms/{form_id}/export", tags=["admin"])
 async def export_submissions(
     request: Request, form_id: str, _: Any = Depends(form_editor_guard)
@@ -1054,35 +1119,48 @@ async def export_submissions(
     order = request.query_params.get("order", "desc")
     sort_submissions(filtered, sort, order, display_columns, master_lookup_by_field)
 
+    correct_map = _parse_correct_map(request.query_params.get("correct"))
+    include_correct = bool(correct_map)
+
     def _fmt(value: Any) -> str:
         if isinstance(value, datetime):
             return value.astimezone().strftime("%Y-%m-%dT%H:%M")
         return str(value or "")
 
-    headers = ["送信日時", "更新日時", "送信ユーザー"] + [
-        column["label"] for column in display_columns
-    ]
-    column_kinds = ["datetime", "datetime", ""] + [
-        _column_export_kind(column) for column in display_columns
-    ]
-    column_wraps = [False, False, False] + [
-        bool(column.get("field", {}).get("multiline")) for column in display_columns
-    ]
-    rows = [
-        [
+    correct_headers = ["正答数", "正答率"] if include_correct else []
+    headers = (
+        ["送信日時", "更新日時", "送信ユーザー"]
+        + correct_headers
+        + [column["label"] for column in display_columns]
+    )
+    column_kinds = (
+        ["datetime", "datetime", ""]
+        + ([""] * len(correct_headers))
+        + [_column_export_kind(column) for column in display_columns]
+    )
+    column_wraps = (
+        [False, False, False]
+        + ([False] * len(correct_headers))
+        + [bool(column.get("field", {}).get("multiline")) for column in display_columns]
+    )
+    rows = []
+    for submission in filtered:
+        data = submission.get("data_json", {})
+        row = [
             _fmt(submission.get("created_at")),
             _fmt(submission.get("updated_at")),
             submission.get("_display_username") or "",
         ]
-        + build_submission_row_values(
-            submission.get("data_json", {}),
+        if include_correct:
+            row += list(_correctness_cells(data, correct_map))
+        row += build_submission_row_values(
+            data,
             display_columns,
             master_lookup_by_field,
             file_names,
             temporal_style="iso",
         )
-        for submission in filtered
-    ]
+        rows.append(row)
 
     fmt = request.query_params.get("format", "csv")
     if fmt not in _EXPORT_FORMATS:

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -97,11 +97,20 @@
       <table class="min-w-full divide-y divide-slate-200 text-sm">
         <thead class="bg-slate-100 text-left">
           <tr>
-            <th class="px-4 py-3">送信日時</th>
-            <th class="px-4 py-3">送信ユーザー</th>
-            <th class="px-4 py-3">正答率</th>
+            <th class="px-4 py-3">
+              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="datetime">送信日時 <span class="js-sort-arrow text-slate-300">↕</span></button>
+            </th>
+            <th class="px-4 py-3">
+              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="text">送信ユーザー <span class="js-sort-arrow text-slate-300">↕</span></button>
+            </th>
+            <th class="px-4 py-3">
+              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="rate">正答率 <span class="js-sort-arrow text-slate-300">↕</span></button>
+            </th>
             {% for column in display_columns %}
-            <th class="px-4 py-3">{{ column.label }}</th>
+            {% set col_numeric = (column.kind == 'default' and column.field.type in ['number', 'integer', 'calculated']) or (column.kind == 'master_display' and column.display_type in ['number', 'integer']) %}
+            <th class="px-4 py-3">
+              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="{{ 'number' if col_numeric else 'text' }}">{{ column.label }} <span class="js-sort-arrow text-slate-300">↕</span></button>
+            </th>
             {% endfor %}
             <th class="px-4 py-3">操作</th>
           </tr>
@@ -317,6 +326,68 @@
     }
 
     document.getElementById("drill-clear")?.addEventListener("click", clearDrill);
+
+    // ---- 列ヘッダーによる並べ替え（クライアント側） ----
+    const tableBody = document.querySelector("#data-table-section tbody");
+    const sortState = { index: null, dir: 1 };
+
+    function cellSortValue(tr, cellIndex, kind) {
+      const cell = tr.cells[cellIndex];
+      if (!cell) return null;
+      if (kind === "datetime") {
+        const timeEl = cell.querySelector("time");
+        const ms = Date.parse(timeEl ? timeEl.dataset.iso : "");
+        return Number.isNaN(ms) ? null : ms;
+      }
+      if (kind === "rate") {
+        const span = cell.querySelector(".js-row-rate");
+        const match = (span ? span.textContent : "").match(/([\d.]+)%/);
+        return match ? parseFloat(match[1]) : null;
+      }
+      if (kind === "number") {
+        const n = parseFloat((cell.textContent || "").replace(/,/g, "").trim());
+        return Number.isNaN(n) ? null : n;
+      }
+      const text = (cell.textContent || "").trim().toLowerCase();
+      return text === "" ? null : text;
+    }
+
+    document.querySelectorAll(".js-sort").forEach((button) => {
+      button.addEventListener("click", () => {
+        if (!tableBody) return;
+        const th = button.closest("th");
+        const cellIndex = th.cellIndex;
+        const kind = button.dataset.sortKind;
+        if (sortState.index === cellIndex) {
+          sortState.dir = -sortState.dir;
+        } else {
+          sortState.index = cellIndex;
+          sortState.dir = 1;
+        }
+        const sorted = tableRows.slice().sort((a, b) => {
+          const va = cellSortValue(a.tr, cellIndex, kind);
+          const vb = cellSortValue(b.tr, cellIndex, kind);
+          if (va === null && vb === null) return 0;
+          if (va === null) return 1;
+          if (vb === null) return -1;
+          if (va < vb) return -sortState.dir;
+          if (va > vb) return sortState.dir;
+          return 0;
+        });
+        sorted.forEach((row) => tableBody.insertBefore(row.tr, emptyRow));
+        document.querySelectorAll(".js-sort-arrow").forEach((arrow) => {
+          arrow.textContent = "↕";
+          arrow.classList.add("text-slate-300");
+          arrow.classList.remove("text-slate-500");
+        });
+        const arrow = button.querySelector(".js-sort-arrow");
+        if (arrow) {
+          arrow.textContent = sortState.dir === 1 ? "▲" : "▼";
+          arrow.classList.remove("text-slate-300");
+          arrow.classList.add("text-slate-500");
+        }
+      });
+    });
 
     // ---- 各送信ごとの正答率 ----
     function getCorrectMap() {

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -282,7 +282,10 @@
 
     // ---- 件数の推移: 送信日時の間隔に応じた粒度バケット ----
     const TS_UNITS = ["second", "minute", "hour", "day", "week", "month", "year"];
-    const TS_TARGET_BUCKETS = 150;
+    // バーが多すぎる粒度は不可。充填率(データの入る区間の割合)がこれ未満なら
+    // 0件区間が多すぎるとみなし、1段階広い粒度を選ぶ。
+    const TS_MAX_BUCKETS = 60;
+    const TS_MIN_FILL = 0.34;
     const TS_UNIT_SECONDS = { second: 1, minute: 60, hour: 3600, day: 86400, week: 604800 };
 
     function tsTruncate(date, unit) {
@@ -332,18 +335,35 @@
       return Math.floor((hi - lo) / (TS_UNIT_SECONDS[unit] * 1000)) + 1;
     }
 
-    function tsAutoUnit(minD, maxD) {
+    function tsFilledCount(dates, unit) {
+      const set = new Set();
+      dates.forEach((d) => set.add(tsLabel(tsTruncate(d, unit), unit)));
+      return set.size;
+    }
+
+    function tsAutoUnit(dates) {
+      // なるべく広い粒度を優先。細→粗に見て、バー数が上限以下で、かつ空区間が
+      // 多すぎない(充填率が十分な)最も細かい粒度を選ぶ。空が多い粒度は飛ばして
+      // 1段階広い粒度へ。
+      const minD = dates[0];
+      const maxD = dates[dates.length - 1];
+      let chosen = "year";
       for (const unit of TS_UNITS) {
-        if (tsBucketCount(minD, maxD, unit) <= TS_TARGET_BUCKETS) return unit;
+        const count = tsBucketCount(minD, maxD, unit);
+        if (count > TS_MAX_BUCKETS) continue;
+        chosen = unit;
+        if (count <= 3 || tsFilledCount(dates, unit) / count >= TS_MIN_FILL) {
+          return unit;
+        }
       }
-      return "year";
+      return chosen;
     }
 
     function buildTimeseries(dates, requested) {
       if (!dates.length) return { labels: [], counts: [], unit: "day" };
       const minD = dates[0], maxD = dates[dates.length - 1];
       const unit = (requested === "auto" || !TS_UNITS.includes(requested))
-        ? tsAutoUnit(minD, maxD) : requested;
+        ? tsAutoUnit(dates) : requested;
       const counter = {};
       dates.forEach((d) => {
         const key = tsLabel(tsTruncate(d, unit), unit);

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -10,7 +10,38 @@
       <p class="text-sm text-slate-600">{{ form.name }} の送信内容を集計します。</p>
     </div>
     <div class="flex gap-2">
+      <button type="button" id="open-download-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">ダウンロード</button>
       <a href="/forms/{{ form.id }}/submissions?{{ build_query(query, page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">送信一覧へ戻る</a>
+    </div>
+  </div>
+
+  <div id="download-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/50 px-4 py-6">
+    <div class="w-full max-w-md rounded-lg border border-slate-200 bg-white shadow-xl">
+      <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+        <h2 class="text-base font-semibold text-slate-900">ダウンロード形式を選択</h2>
+        <button type="button" data-action="close-download-modal" class="rounded border border-slate-300 px-3 py-1.5 text-xs text-slate-700">閉じる</button>
+      </div>
+      <div class="p-4">
+        <p class="text-xs text-slate-500">現在の検索・フィルター条件に一致する送信内容をダウンロードします。</p>
+        <div class="mt-3 grid gap-2">
+          <a href="/forms/{{ form.id }}/export?{{ build_query(query, format='xlsx', page=None) }}" class="flex items-center justify-between rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50">
+            <span class="font-medium text-slate-900">Excel</span>
+            <span class="text-xs text-slate-500">.xlsx</span>
+          </a>
+          <a href="/forms/{{ form.id }}/export?{{ build_query(query, format='csv', page=None) }}" class="flex items-center justify-between rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50">
+            <span class="font-medium text-slate-900">CSV</span>
+            <span class="text-xs text-slate-500">.csv</span>
+          </a>
+          <a href="/forms/{{ form.id }}/export?{{ build_query(query, format='parquet', page=None) }}" class="flex items-center justify-between rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50">
+            <span class="font-medium text-slate-900">Parquet</span>
+            <span class="text-xs text-slate-500">.parquet</span>
+          </a>
+          <a href="/forms/{{ form.id }}/export?{{ build_query(query, format='json', page=None) }}" class="flex items-center justify-between rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50">
+            <span class="font-medium text-slate-900">JSON</span>
+            <span class="text-xs text-slate-500">.json</span>
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -26,13 +57,13 @@
         <span>粒度</span>
         <select id="ts-unit-select" class="rounded border border-slate-300 px-2 py-1 text-sm">
           <option value="auto">自動</option>
-          <option value="second">秒</option>
-          <option value="minute">分</option>
-          <option value="hour">時</option>
-          <option value="day">日</option>
-          <option value="week">週</option>
-          <option value="month">月</option>
           <option value="year">年</option>
+          <option value="month">月</option>
+          <option value="week">週</option>
+          <option value="day">日</option>
+          <option value="hour">時</option>
+          <option value="minute">分</option>
+          <option value="second">秒</option>
         </select>
       </label>
     </div>
@@ -134,6 +165,9 @@
               <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="text">送信ユーザー <span class="js-sort-arrow text-slate-300">↕</span></button>
             </th>
             <th class="px-4 py-3">
+              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="number">正答数 <span class="js-sort-arrow text-slate-300">↕</span></button>
+            </th>
+            <th class="px-4 py-3">
               <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="rate">正答率 <span class="js-sort-arrow text-slate-300">↕</span></button>
             </th>
             {% for column in display_columns %}
@@ -152,6 +186,7 @@
               <time class="js-local-dt" data-iso="{{ iso_dt(row.created_at) }}">{{ format_dt(row.created_at) }}</time>
             </td>
             <td class="px-4 py-3 text-slate-600">{{ row.username or '-' }}</td>
+            <td class="px-4 py-3 text-slate-700"><span class="js-row-correct tabular-nums">—</span></td>
             <td class="px-4 py-3 text-slate-700"><span class="js-row-rate tabular-nums">—</span></td>
             {% for value in row["values"] %}
             {% set column = display_columns[loop.index0] %}
@@ -195,7 +230,7 @@
           </tr>
           {% endfor %}
           <tr id="drill-empty-row" class="hidden">
-            <td colspan="{{ display_columns | length + 4 }}" class="px-4 py-6 text-center text-slate-500">該当データがありません。</td>
+            <td colspan="{{ display_columns | length + 5 }}" class="px-4 py-6 text-center text-slate-500">該当データがありません。</td>
           </tr>
         </tbody>
       </table>
@@ -219,7 +254,13 @@
     const tableRows = Array.from(document.querySelectorAll("tr[data-row]")).map((tr) => {
       let data = {};
       try { data = JSON.parse(tr.dataset.row); } catch (e) {}
-      return { tr, data, ts: tr.dataset.ts || "", rateCell: tr.querySelector(".js-row-rate") };
+      return {
+        tr,
+        data,
+        ts: tr.dataset.ts || "",
+        rateCell: tr.querySelector(".js-row-rate"),
+        countCell: tr.querySelector(".js-row-correct"),
+      };
     });
     const emptyRow = document.getElementById("drill-empty-row");
     const banner = document.getElementById("drill-banner");
@@ -510,6 +551,34 @@
 
     document.getElementById("drill-clear")?.addEventListener("click", clearDrill);
 
+    // ---- ダウンロード（送信一覧と同じ形式選択モーダル） ----
+    const downloadModal = document.getElementById("download-modal");
+    function openDownloadModal() {
+      if (!downloadModal) return;
+      downloadModal.classList.remove("hidden");
+      downloadModal.classList.add("flex");
+      document.body.classList.add("overflow-hidden");
+    }
+    function closeDownloadModal() {
+      if (!downloadModal) return;
+      downloadModal.classList.add("hidden");
+      downloadModal.classList.remove("flex");
+      document.body.classList.remove("overflow-hidden");
+    }
+    document.getElementById("open-download-modal")?.addEventListener("click", openDownloadModal);
+    document.querySelectorAll('[data-action="close-download-modal"]').forEach((btn) => {
+      btn.addEventListener("click", closeDownloadModal);
+    });
+    downloadModal?.addEventListener("click", (event) => {
+      if (event.target === downloadModal) closeDownloadModal();
+    });
+    downloadModal?.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", closeDownloadModal);
+    });
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") closeDownloadModal();
+    });
+
     // ---- 列ヘッダーによる並べ替え（クライアント側） ----
     const tableBody = document.querySelector("#data-table-section tbody");
     const sortState = { index: null, dir: 1 };
@@ -619,14 +688,18 @@
       const correctMap = getCorrectMap();
       const keys = Object.keys(correctMap);
       tableRows.forEach((row) => {
-        if (!row.rateCell) return;
-        if (!keys.length) { row.rateCell.textContent = "—"; return; }
+        if (!keys.length) {
+          if (row.rateCell) row.rateCell.textContent = "—";
+          if (row.countCell) row.countCell.textContent = "—";
+          return;
+        }
         let correct = 0;
         keys.forEach((key) => {
           if (isRowCorrect(row.data, key, correctMap[key])) correct += 1;
         });
         const rate = (correct / keys.length) * 100;
-        row.rateCell.textContent = rate.toFixed(0) + "% (" + correct + "/" + keys.length + ")";
+        if (row.countCell) row.countCell.textContent = correct + " / " + keys.length;
+        if (row.rateCell) row.rateCell.textContent = rate.toFixed(0) + "%";
       });
     }
 

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -553,8 +553,24 @@
 
     // ---- ダウンロード（送信一覧と同じ形式選択モーダル） ----
     const downloadModal = document.getElementById("download-modal");
+    const downloadLinks = downloadModal
+      ? Array.from(downloadModal.querySelectorAll("a"))
+      : [];
+    downloadLinks.forEach((a) => { a.dataset.baseHref = a.getAttribute("href"); });
+
+    function updateDownloadLinks() {
+      // 正解が1つ以上設定されている場合だけ、正答数・正答率を含めるよう
+      // correct パラメータを付与する（サーバー側で列を追加）。
+      const correctMap = getCorrectMap();
+      const param = Object.keys(correctMap).length
+        ? "&correct=" + encodeURIComponent(JSON.stringify(correctMap))
+        : "";
+      downloadLinks.forEach((a) => { a.setAttribute("href", a.dataset.baseHref + param); });
+    }
+
     function openDownloadModal() {
       if (!downloadModal) return;
+      updateDownloadLinks();
       downloadModal.classList.remove("hidden");
       downloadModal.classList.add("flex");
       document.body.classList.add("overflow-hidden");

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -51,21 +51,32 @@
         </div>
         {% if agg.supports_correct %}
         <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}" data-correct-array="{{ '1' if agg.is_array else '' }}">
-          <div class="text-xs font-semibold text-slate-500">正解を指定</div>
-          <div class="mt-2 flex flex-wrap gap-3 text-sm">
-            {% for label in agg.labels %}
-            <label class="inline-flex items-center gap-1">
-              <input type="checkbox" class="js-correct-option" value="{{ label }}" data-count="{{ agg.counts[loop.index0] }}" />
-              <span>{{ label }}</span>
-              {% if agg.is_array %}<sup class="js-order-badge font-semibold text-sky-600"></sup>{% endif %}
-            </label>
-            {% endfor %}
-          </div>
+          <div class="text-xs font-semibold text-slate-500">正解</div>
           {% if agg.is_array %}
+          <div class="js-correct-rows mt-2 space-y-2"></div>
+          <button type="button" class="js-correct-add mt-1 rounded border border-slate-300 px-3 py-1 text-xs">追加</button>
+          <template class="js-correct-row-template">
+            <div class="flex items-center gap-2 js-correct-row">
+              <select class="js-correct-select w-full max-w-xs rounded border border-slate-300 px-2 py-1 text-sm">
+                <option value="">選択してください</option>
+                {% for label in agg.labels %}
+                <option value="{{ label }}">{{ label }}</option>
+                {% endfor %}
+              </select>
+              <button type="button" class="js-correct-remove shrink-0 whitespace-nowrap rounded border border-rose-300 px-2 py-1 text-xs text-rose-600">削除</button>
+            </div>
+          </template>
           <label class="mt-2 inline-flex items-center gap-1 text-xs text-slate-500">
             <input type="checkbox" class="js-correct-ordered" />
             <span>順番も一致させる</span>
           </label>
+          {% else %}
+          <select class="js-correct-single mt-2 w-full max-w-xs rounded border border-slate-300 px-2 py-1 text-sm">
+            <option value="">指定なし</option>
+            {% for label in agg.labels %}
+            <option value="{{ label }}">{{ label }}</option>
+            {% endfor %}
+          </select>
           {% endif %}
           <div class="mt-2 text-sm text-slate-700">正答率: <span class="js-correct-rate font-semibold" data-total="{{ agg.total }}">—</span></div>
         </div>
@@ -423,25 +434,29 @@
       });
     });
 
+    // ---- 正解の読み取り（選択肢フィールドの入力UIに準拠） ----
+    function readCorrectInfo(container) {
+      const orderedEl = container.querySelector(".js-correct-ordered");
+      if (container.dataset.correctArray === "1") {
+        const list = Array.from(container.querySelectorAll(".js-correct-rows .js-correct-select"))
+          .map((s) => s.value)
+          .filter((v) => v !== "");
+        return { mode: "array", list: list, ordered: !!(orderedEl && orderedEl.checked) };
+      }
+      const single = container.querySelector(".js-correct-single");
+      return { mode: "single", value: single ? single.value : "" };
+    }
+
+    function correctInfoValid(info) {
+      return info.mode === "array" ? info.list.length > 0 : info.value !== "";
+    }
+
     // ---- 各送信ごとの正答率 ----
     function getCorrectMap() {
       const map = {};
       document.querySelectorAll("[data-correct-field]").forEach((container) => {
-        const checked = Array.from(container.querySelectorAll(".js-correct-option"))
-          .filter((o) => o.checked)
-          .map((o) => o.value);
-        if (!checked.length) return;
-        // チェックを付けた順番（data-correct-order）を正解の並び順として採用する
-        let order = [];
-        try { order = JSON.parse(container.dataset.correctOrder || "[]"); } catch (e) {}
-        const checkedSet = new Set(checked);
-        const set = order.filter((v) => checkedSet.has(v));
-        checked.forEach((v) => { if (!set.includes(v)) set.push(v); });
-        const orderedEl = container.querySelector(".js-correct-ordered");
-        map[container.dataset.correctField] = {
-          set: set,
-          ordered: !!(orderedEl && orderedEl.checked),
-        };
+        const info = readCorrectInfo(container);
+        if (correctInfoValid(info)) map[container.dataset.correctField] = info;
       });
       return map;
     }
@@ -449,19 +464,18 @@
     function isRowCorrect(rowData, key, info) {
       const v = rowData[key];
       if (v === undefined || v === null) return false;
-      const correctSet = info.set;
-      if (Array.isArray(v)) {
-        // 配列（複数選択）は過不足のない完全一致が必要
-        const a = v.map(String);
-        if (a.length !== correctSet.length) return false;
-        if (info.ordered) {
-          return a.every((x, i) => x === correctSet[i]);
-        }
+      if (info.mode === "array") {
+        // 配列(複数選択)は重複・件数も含めた過不足のない完全一致
+        const a = (Array.isArray(v) ? v : [v]).map(String);
+        const b = info.list;
+        if (a.length !== b.length) return false;
+        if (info.ordered) return a.every((x, i) => x === b[i]);
         const sa = a.slice().sort();
-        const sb = correctSet.slice().sort();
+        const sb = b.slice().sort();
         return sa.every((x, i) => x === sb[i]);
       }
-      return correctSet.includes(String(v));
+      if (Array.isArray(v)) return false;
+      return String(v) === info.value;
     }
 
     function recomputeRowRates() {
@@ -479,103 +493,85 @@
       });
     }
 
-    // ---- 設問ごとの正答率（円/棒の下の表示）と localStorage 復元 ----
+    function recomputeFieldRate(container) {
+      const rateEl = container.querySelector(".js-correct-rate");
+      if (!rateEl) return;
+      const info = readCorrectInfo(container);
+      if (!correctInfoValid(info)) { rateEl.textContent = "—"; return; }
+      const fieldKey = container.dataset.correctField;
+      let answered = 0;
+      let correct = 0;
+      tableRows.forEach((row) => {
+        const v = row.data[fieldKey];
+        const hasAnswer = Array.isArray(v) ? v.length > 0 : (v !== undefined && v !== null && v !== "");
+        if (!hasAnswer) return;
+        answered += 1;
+        if (isRowCorrect(row.data, fieldKey, info)) correct += 1;
+      });
+      if (answered === 0) { rateEl.textContent = "—"; return; }
+      const rate = (correct / answered) * 100;
+      rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + answered + ")";
+    }
+
+    // ---- 設問ごとの正解入力 UI と localStorage 復元 ----
     document.querySelectorAll("[data-correct-field]").forEach((container) => {
       const storageKey = "sf-correct:" + formId + ":" + container.dataset.correctField;
-      const rateEl = container.querySelector(".js-correct-rate");
-      const total = parseFloat(rateEl.dataset.total) || 0;
-      const options = Array.from(container.querySelectorAll(".js-correct-option"));
-      const orderedEl = container.querySelector(".js-correct-ordered");
-      const fieldKey = container.dataset.correctField;
       const isArrayField = container.dataset.correctArray === "1";
-      let checkOrder = [];
+      const orderedEl = container.querySelector(".js-correct-ordered");
 
-      function syncCheckOrder() {
-        // チェックされている値を、付けた順番を保ったまま保持する
-        const checkedValues = options.filter((o) => o.checked).map((o) => o.value);
-        checkOrder = checkOrder.filter((v) => checkedValues.includes(v));
-        checkedValues.forEach((v) => { if (!checkOrder.includes(v)) checkOrder.push(v); });
-        container.dataset.correctOrder = JSON.stringify(checkOrder);
-      }
-
-      function updateBadges() {
-        const showOrder = isArrayField && orderedEl && orderedEl.checked;
-        options.forEach((o) => {
-          const badge = o.closest("label").querySelector(".js-order-badge");
-          if (!badge) return;
-          if (showOrder && o.checked) {
-            const idx = checkOrder.indexOf(o.value);
-            badge.textContent = idx >= 0 ? String(idx + 1) : "";
-          } else {
-            badge.textContent = "";
-          }
-        });
-      }
-
-      function recomputeField() {
-        syncCheckOrder();
-        updateBadges();
-        const selectedValues = checkOrder.slice();
-        if (selectedValues.length === 0) {
-          rateEl.textContent = "—";
-        } else if (isArrayField) {
-          // 配列(複数選択)は延べ選択数ではなく、行単位の完全一致で正答した
-          // 送信数を数え、回答済み件数で割る（表の行単位と一致させる）
-          const info = { set: selectedValues, ordered: orderedEl ? orderedEl.checked : false };
-          let answered = 0;
-          let correct = 0;
-          tableRows.forEach((row) => {
-            const v = row.data[fieldKey];
-            const hasAnswer = Array.isArray(v) ? v.length > 0 : (v !== undefined && v !== null && v !== "");
-            if (!hasAnswer) return;
-            answered += 1;
-            if (isRowCorrect(row.data, fieldKey, info)) correct += 1;
-          });
-          const rate = answered > 0 ? (correct / answered * 100) : 0;
-          rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + answered + ")";
-        } else {
-          const correct = options.filter((o) => o.checked)
-            .reduce((acc, o) => acc + (parseFloat(o.dataset.count) || 0), 0);
-          const rate = total > 0 ? (correct / total * 100) : 0;
-          rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + total + ")";
-        }
+      function onChange() {
+        recomputeFieldRate(container);
+        recomputeRowRates();
         try {
-          localStorage.setItem(storageKey, JSON.stringify({
-            options: selectedValues,
-            ordered: orderedEl ? orderedEl.checked : false,
-          }));
+          localStorage.setItem(storageKey, JSON.stringify(readCorrectInfo(container)));
         } catch (e) {}
       }
 
-      try {
-        const saved = JSON.parse(localStorage.getItem(storageKey) || "null");
-        let savedOptions = [];
-        let savedOrdered = false;
-        if (Array.isArray(saved)) {
-          savedOptions = saved;
-        } else if (saved && typeof saved === "object") {
-          savedOptions = saved.options || [];
-          savedOrdered = !!saved.ordered;
-        }
-        const validValues = options.map((o) => o.value);
-        savedOptions.forEach((v) => {
-          const opt = options.find((o) => o.value === v);
-          if (opt) opt.checked = true;
-        });
-        // 保存された並び順をチェック順として復元する
-        checkOrder = savedOptions.filter((v) => validValues.includes(v));
-        if (orderedEl) orderedEl.checked = savedOrdered;
-      } catch (e) {}
+      let saved = null;
+      try { saved = JSON.parse(localStorage.getItem(storageKey) || "null"); } catch (e) {}
 
-      options.forEach((o) => o.addEventListener("change", () => {
-        recomputeField();
-        recomputeRowRates();
-      }));
-      if (orderedEl) orderedEl.addEventListener("change", () => {
-        recomputeField();
-        recomputeRowRates();
-      });
-      recomputeField();
+      if (isArrayField) {
+        const rowsEl = container.querySelector(".js-correct-rows");
+        const template = container.querySelector(".js-correct-row-template");
+        const addBtn = container.querySelector(".js-correct-add");
+        const validValues = Array.from(
+          template.content.querySelectorAll(".js-correct-select option")
+        ).map((o) => o.value);
+
+        function addRow(value) {
+          const node = template.content.firstElementChild.cloneNode(true);
+          const select = node.querySelector(".js-correct-select");
+          if (value && validValues.includes(value)) select.value = value;
+          select.addEventListener("change", onChange);
+          node.querySelector(".js-correct-remove").addEventListener("click", () => {
+            node.remove();
+            onChange();
+          });
+          rowsEl.appendChild(node);
+        }
+
+        addBtn.addEventListener("click", () => addRow(""));
+        if (orderedEl) orderedEl.addEventListener("change", onChange);
+
+        // 復元（新旧フォーマット対応）
+        let list = [];
+        let ordered = false;
+        if (Array.isArray(saved)) { list = saved; }
+        else if (saved && saved.mode === "array") { list = saved.list || []; ordered = !!saved.ordered; }
+        else if (saved && Array.isArray(saved.options)) { list = saved.options; ordered = !!saved.ordered; }
+        list.forEach((v) => addRow(v));
+        if (orderedEl) orderedEl.checked = ordered;
+      } else {
+        const single = container.querySelector(".js-correct-single");
+        single.addEventListener("change", onChange);
+        let value = "";
+        if (saved && saved.mode === "single") value = saved.value || "";
+        else if (saved && Array.isArray(saved.options) && saved.options.length) value = saved.options[0];
+        else if (Array.isArray(saved) && saved.length) value = saved[0];
+        if (value && Array.from(single.options).some((o) => o.value === value)) single.value = value;
+      }
+
+      recomputeFieldRate(container);
     });
 
     recomputeRowRates();

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -145,6 +145,14 @@
     {% endfor %}
   </div>
 
+  <div id="correct-dist-section" class="mt-6 hidden rounded-lg border border-slate-200 bg-white p-4">
+    <h2 class="text-base font-semibold text-slate-900">正答数の分布</h2>
+    <div class="relative mt-3 h-64">
+      <canvas id="correct-dist-chart"></canvas>
+    </div>
+    <p class="mt-2 text-xs text-slate-400">正解を指定すると表示されます。グラフをクリックすると、その正答数の送信のみ表に表示します。</p>
+  </div>
+
   <div id="data-table-section" class="mt-8">
     <div class="flex flex-wrap items-center justify-between gap-2">
       <h2 class="text-lg font-semibold text-slate-900">元データ</h2>
@@ -499,6 +507,21 @@
           test: (row) => toBool(row.data[spec.field]) === target,
         };
       }
+      if (spec.ckind === "correctcount") {
+        const correctMap = getCorrectMap();
+        const keys = Object.keys(correctMap);
+        const target = parseInt(clickedLabel, 10);
+        return {
+          label: "正答数: " + clickedLabel,
+          test: (row) => {
+            let count = 0;
+            keys.forEach((key) => {
+              if (isRowCorrect(row.data, key, correctMap[key])) count += 1;
+            });
+            return count === target;
+          },
+        };
+      }
       if (spec.ckind === "numeric") {
         const range = spec.ranges[index];
         const isLast = index === spec.ranges.length - 1;
@@ -712,6 +735,36 @@
         if (row.countCell) row.countCell.textContent = String(correct);
         if (row.rateCell) row.rateCell.textContent = rate.toFixed(0);
       });
+      renderCorrectDistribution();
+    }
+
+    // ---- 正答数の分布（正解が1つ以上設定されている場合に表示） ----
+    const correctDistSection = document.getElementById("correct-dist-section");
+    const correctDistCanvas = document.getElementById("correct-dist-chart");
+    let correctDistChart = null;
+
+    function renderCorrectDistribution() {
+      if (!correctDistSection || !correctDistCanvas) return;
+      const correctMap = getCorrectMap();
+      const keys = Object.keys(correctMap);
+      if (!keys.length) {
+        correctDistSection.classList.add("hidden");
+        if (correctDistChart) { correctDistChart.destroy(); correctDistChart = null; }
+        return;
+      }
+      const counts = new Array(keys.length + 1).fill(0);
+      tableRows.forEach((row) => {
+        let correct = 0;
+        keys.forEach((key) => {
+          if (isRowCorrect(row.data, key, correctMap[key])) correct += 1;
+        });
+        counts[correct] += 1;
+      });
+      const labels = counts.map((_, i) => String(i));
+      const spec = { type: "bar", labels, counts, label: "件数", ckind: "correctcount", flabel: "正答数" };
+      correctDistSection.classList.remove("hidden");
+      if (correctDistChart) correctDistChart.destroy();
+      correctDistChart = new Chart(correctDistCanvas, buildConfig(spec));
     }
 
     function recomputeFieldRate(container) {

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -227,7 +227,20 @@
             if (!elements.length) return;
             applyDrill(spec, elements[0].index);
           },
-          plugins: { legend: { display: isPie } },
+          plugins: {
+            legend: { display: isPie },
+            tooltip: {
+              callbacks: {
+                label: (ctx) => {
+                  const value = typeof ctx.raw === "number" ? ctx.raw : (ctx.parsed.y ?? ctx.parsed);
+                  const data = ctx.dataset.data || [];
+                  const total = data.reduce((sum, v) => sum + (Number(v) || 0), 0);
+                  const pct = total > 0 ? (value / total * 100).toFixed(1) : "0.0";
+                  return value + "件 (" + pct + "%)";
+                },
+              },
+            },
+          },
           scales: isPie ? {} : { y: { beginAtZero: true, ticks: { precision: 0 } } },
         },
       };

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -191,7 +191,7 @@
         </thead>
         <tbody class="divide-y divide-slate-200">
           {% for row in rows %}
-          <tr data-row="{{ row.drill | tojson_attr }}" data-ts="{{ row.ts }}">
+          <tr data-row="{{ row.drill | tojson_attr }}" data-ts="{{ row.ts }}" data-id="{{ row.id }}">
             <td class="px-4 py-3 text-slate-600">
               <time class="js-local-dt" data-iso="{{ iso_dt(row.created_at) }}">{{ format_dt(row.created_at) }}</time>
             </td>
@@ -260,6 +260,7 @@
       "#db2777", "#65a30d", "#ea580c", "#4f46e5", "#0d9488", "#9333ea",
     ];
     const charts = {};
+    let drillActive = false;
 
     const tableRows = Array.from(document.querySelectorAll("tr[data-row]")).map((tr) => {
       let data = {};
@@ -268,6 +269,7 @@
         tr,
         data,
         ts: tr.dataset.ts || "",
+        id: tr.dataset.id || "",
         rateCell: tr.querySelector(".js-row-rate"),
         countCell: tr.querySelector(".js-row-correct"),
       };
@@ -570,6 +572,7 @@
     function applyDrill(spec, index, chart) {
       const predicate = buildPredicate(spec, index, chart);
       if (!predicate) return;
+      drillActive = true;
       let count = 0;
       tableRows.forEach((row) => {
         const ok = predicate.test(row);
@@ -588,6 +591,7 @@
     }
 
     function clearDrill() {
+      drillActive = false;
       tableRows.forEach((row) => row.tr.classList.remove("hidden"));
       if (emptyRow) emptyRow.classList.add("hidden");
       if (banner) {
@@ -609,9 +613,17 @@
       // 正解が1つ以上設定されている場合だけ、正答数・正答率を含めるよう
       // correct パラメータを付与する（サーバー側で列を追加）。
       const correctMap = getCorrectMap();
-      const param = Object.keys(correctMap).length
+      let param = Object.keys(correctMap).length
         ? "&correct=" + encodeURIComponent(JSON.stringify(correctMap))
         : "";
+      // グラフクリックで絞り込み中は、表示中の送信のみダウンロードする。
+      if (drillActive) {
+        const ids = tableRows
+          .filter((r) => !r.tr.classList.contains("hidden"))
+          .map((r) => r.id)
+          .filter(Boolean);
+        param += "&ids=" + encodeURIComponent(ids.join(","));
+      }
       downloadLinks.forEach((a) => { a.setAttribute("href", a.dataset.baseHref + param); });
     }
 

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -18,11 +18,26 @@
   <div class="mt-6 rounded-lg border border-slate-200 bg-white px-4 py-10 text-center text-slate-500">該当データがありません。</div>
   {% else %}
 
-  {% if timeseries.labels %}
-  <div class="mt-6 rounded-lg border border-slate-200 bg-white p-4">
-    <h2 class="text-base font-semibold text-slate-900">日付別の件数推移</h2>
+  {% if timeseries_timestamps %}
+  <div id="timeseries-section" class="mt-6 rounded-lg border border-slate-200 bg-white p-4" data-timestamps="{{ timeseries_timestamps | tojson_attr }}">
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <h2 class="text-base font-semibold text-slate-900">件数の推移</h2>
+      <label class="flex items-center gap-1 text-xs text-slate-500">
+        <span>粒度</span>
+        <select id="ts-unit-select" class="rounded border border-slate-300 px-2 py-1 text-sm">
+          <option value="auto">自動</option>
+          <option value="second">秒</option>
+          <option value="minute">分</option>
+          <option value="hour">時</option>
+          <option value="day">日</option>
+          <option value="week">週</option>
+          <option value="month">月</option>
+          <option value="year">年</option>
+        </select>
+      </label>
+    </div>
     <div class="relative mt-3 h-64">
-      <canvas class="js-chart" data-chart="{{ {'type': 'line', 'labels': timeseries.labels, 'counts': timeseries.counts, 'label': '件数', 'ckind': 'date', 'flabel': '送信日'} | tojson_attr }}"></canvas>
+      <canvas id="ts-chart"></canvas>
     </div>
     <p class="mt-2 text-xs text-slate-400">グラフをクリックすると、下の表に該当データのみを表示します。</p>
   </div>
@@ -132,7 +147,7 @@
         </thead>
         <tbody class="divide-y divide-slate-200">
           {% for row in rows %}
-          <tr data-row="{{ row.drill | tojson_attr }}" data-date="{{ row.date }}">
+          <tr data-row="{{ row.drill | tojson_attr }}" data-ts="{{ row.ts }}">
             <td class="px-4 py-3 text-slate-600">
               <time class="js-local-dt" data-iso="{{ iso_dt(row.created_at) }}">{{ format_dt(row.created_at) }}</time>
             </td>
@@ -204,7 +219,7 @@
     const tableRows = Array.from(document.querySelectorAll("tr[data-row]")).map((tr) => {
       let data = {};
       try { data = JSON.parse(tr.dataset.row); } catch (e) {}
-      return { tr, data, date: tr.dataset.date || "", rateCell: tr.querySelector(".js-row-rate") };
+      return { tr, data, ts: tr.dataset.ts || "", rateCell: tr.querySelector(".js-row-rate") };
     });
     const emptyRow = document.getElementById("drill-empty-row");
     const banner = document.getElementById("drill-banner");
@@ -214,6 +229,89 @@
     function toBool(value) {
       if (Array.isArray(value)) value = value[0];
       return value === true || (typeof value === "string" && ["true", "1", "yes", "on"].includes(value.toLowerCase()));
+    }
+
+    // ---- 件数の推移: 送信日時の間隔に応じた粒度バケット ----
+    const TS_UNITS = ["second", "minute", "hour", "day", "week", "month", "year"];
+    const TS_TARGET_BUCKETS = 150;
+    const TS_UNIT_SECONDS = { second: 1, minute: 60, hour: 3600, day: 86400, week: 604800 };
+
+    function tsTruncate(date, unit) {
+      const Y = date.getFullYear(), Mo = date.getMonth(), D = date.getDate();
+      const H = date.getHours(), Mi = date.getMinutes(), S = date.getSeconds();
+      if (unit === "second") return new Date(Y, Mo, D, H, Mi, S);
+      if (unit === "minute") return new Date(Y, Mo, D, H, Mi, 0);
+      if (unit === "hour") return new Date(Y, Mo, D, H, 0, 0);
+      if (unit === "day") return new Date(Y, Mo, D, 0, 0, 0);
+      if (unit === "week") {
+        const d = new Date(Y, Mo, D);
+        d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+        return d;
+      }
+      if (unit === "month") return new Date(Y, Mo, 1);
+      return new Date(Y, 0, 1);
+    }
+
+    function tsNext(date, unit) {
+      const d = new Date(date.getTime());
+      if (unit === "second") d.setSeconds(d.getSeconds() + 1);
+      else if (unit === "minute") d.setMinutes(d.getMinutes() + 1);
+      else if (unit === "hour") d.setHours(d.getHours() + 1);
+      else if (unit === "day") d.setDate(d.getDate() + 1);
+      else if (unit === "week") d.setDate(d.getDate() + 7);
+      else if (unit === "month") d.setMonth(d.getMonth() + 1);
+      else d.setFullYear(d.getFullYear() + 1);
+      return d;
+    }
+
+    function tsLabel(date, unit) {
+      const pad = (n) => String(n).padStart(2, "0");
+      const Y = date.getFullYear(), Mo = pad(date.getMonth() + 1), D = pad(date.getDate());
+      const H = pad(date.getHours()), Mi = pad(date.getMinutes()), S = pad(date.getSeconds());
+      if (unit === "second") return Y + "-" + Mo + "-" + D + " " + H + ":" + Mi + ":" + S;
+      if (unit === "minute") return Y + "-" + Mo + "-" + D + " " + H + ":" + Mi;
+      if (unit === "hour") return Y + "-" + Mo + "-" + D + " " + H + ":00";
+      if (unit === "day" || unit === "week") return Y + "-" + Mo + "-" + D;
+      if (unit === "month") return Y + "-" + Mo;
+      return String(Y);
+    }
+
+    function tsBucketCount(minD, maxD, unit) {
+      const lo = tsTruncate(minD, unit), hi = tsTruncate(maxD, unit);
+      if (unit === "year") return hi.getFullYear() - lo.getFullYear() + 1;
+      if (unit === "month") return (hi.getFullYear() - lo.getFullYear()) * 12 + (hi.getMonth() - lo.getMonth()) + 1;
+      return Math.floor((hi - lo) / (TS_UNIT_SECONDS[unit] * 1000)) + 1;
+    }
+
+    function tsAutoUnit(minD, maxD) {
+      for (const unit of TS_UNITS) {
+        if (tsBucketCount(minD, maxD, unit) <= TS_TARGET_BUCKETS) return unit;
+      }
+      return "year";
+    }
+
+    function buildTimeseries(dates, requested) {
+      if (!dates.length) return { labels: [], counts: [], unit: "day" };
+      const minD = dates[0], maxD = dates[dates.length - 1];
+      const unit = (requested === "auto" || !TS_UNITS.includes(requested))
+        ? tsAutoUnit(minD, maxD) : requested;
+      const counter = {};
+      dates.forEach((d) => {
+        const key = tsLabel(tsTruncate(d, unit), unit);
+        counter[key] = (counter[key] || 0) + 1;
+      });
+      const labels = [], counts = [];
+      let cur = tsTruncate(minD, unit);
+      const end = tsTruncate(maxD, unit);
+      let guard = 0;
+      while (cur <= end && guard < 2000) {
+        const key = tsLabel(cur, unit);
+        labels.push(key);
+        counts.push(counter[key] || 0);
+        cur = tsNext(cur, unit);
+        guard += 1;
+      }
+      return { labels, counts, unit };
     }
 
     function buildConfig(spec) {
@@ -280,6 +378,40 @@
       if (canvas.id) charts[canvas.id] = { chart, spec };
     });
 
+    // 件数の推移（送信日時の間隔で粒度を自動選択、手動切替も可能）
+    const tsSection = document.getElementById("timeseries-section");
+    if (tsSection) {
+      let timestamps = [];
+      try { timestamps = JSON.parse(tsSection.dataset.timestamps || "[]"); } catch (e) {}
+      const tsDates = timestamps
+        .map((s) => new Date(s))
+        .filter((d) => !Number.isNaN(d.getTime()))
+        .sort((a, b) => a - b);
+      const tsCanvas = document.getElementById("ts-chart");
+      const tsUnitSelect = document.getElementById("ts-unit-select");
+      let tsChart = null;
+
+      const renderTimeseries = () => {
+        if (!tsCanvas || !tsDates.length) return;
+        const requested = tsUnitSelect ? tsUnitSelect.value : "auto";
+        const built = buildTimeseries(tsDates, requested);
+        const spec = {
+          type: "line",
+          labels: built.labels,
+          counts: built.counts,
+          label: "件数",
+          ckind: "date",
+          flabel: "送信日時",
+          unit: built.unit,
+        };
+        if (tsChart) tsChart.destroy();
+        tsChart = new Chart(tsCanvas, buildConfig(spec));
+      };
+
+      if (tsUnitSelect) tsUnitSelect.addEventListener("change", renderTimeseries);
+      renderTimeseries();
+    }
+
     document.querySelectorAll(".js-chart-toggle").forEach((button) => {
       button.addEventListener("click", () => {
         const entry = charts[button.dataset.target];
@@ -296,8 +428,17 @@
       // 円グラフは並べ替えるため、クリックされたラベルはチャート本体から取得する
       const clickedLabel = chart ? chart.data.labels[index] : spec.labels[index];
       if (spec.ckind === "date") {
-        const day = clickedLabel;
-        return { label: spec.flabel + ": " + day, test: (row) => row.date === day };
+        const unit = spec.unit || "day";
+        const target = clickedLabel;
+        return {
+          label: spec.flabel + ": " + target,
+          test: (row) => {
+            if (!row.ts) return false;
+            const d = new Date(row.ts);
+            if (Number.isNaN(d.getTime())) return false;
+            return tsLabel(tsTruncate(d, unit), unit) === target;
+          },
+        };
       }
       if (spec.ckind === "enum") {
         const target = clickedLabel;

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -168,7 +168,7 @@
               <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="number">正答数 <span class="js-sort-arrow text-slate-300">↕</span></button>
             </th>
             <th class="px-4 py-3">
-              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="rate">正答率 <span class="js-sort-arrow text-slate-300">↕</span></button>
+              <button type="button" class="js-sort group inline-flex items-center gap-1" data-sort-kind="number">正答率 <span class="js-sort-arrow text-slate-300">↕</span></button>
             </th>
             {% for column in display_columns %}
             {% set col_numeric = (column.kind == 'default' and column.field.type in ['number', 'integer', 'calculated']) or (column.kind == 'master_display' and column.display_type in ['number', 'integer']) %}
@@ -607,11 +607,6 @@
         const ms = Date.parse(timeEl ? timeEl.dataset.iso : "");
         return Number.isNaN(ms) ? null : ms;
       }
-      if (kind === "rate") {
-        const span = cell.querySelector(".js-row-rate");
-        const match = (span ? span.textContent : "").match(/([\d.]+)%/);
-        return match ? parseFloat(match[1]) : null;
-      }
       if (kind === "number") {
         const n = parseFloat((cell.textContent || "").replace(/,/g, "").trim());
         return Number.isNaN(n) ? null : n;
@@ -714,8 +709,8 @@
           if (isRowCorrect(row.data, key, correctMap[key])) correct += 1;
         });
         const rate = (correct / keys.length) * 100;
-        if (row.countCell) row.countCell.textContent = correct + " / " + keys.length;
-        if (row.rateCell) row.rateCell.textContent = rate.toFixed(0) + "%";
+        if (row.countCell) row.countCell.textContent = String(correct);
+        if (row.rateCell) row.rateCell.textContent = rate.toFixed(0);
       });
     }
 

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -60,6 +60,12 @@
             </label>
             {% endfor %}
           </div>
+          {% if agg.is_array %}
+          <label class="mt-2 inline-flex items-center gap-1 text-xs text-slate-500">
+            <input type="checkbox" class="js-correct-ordered" />
+            <span>順番も一致させる</span>
+          </label>
+          {% endif %}
           <div class="mt-2 text-sm text-slate-700">正答率: <span class="js-correct-rate font-semibold" data-total="{{ agg.total }}">—</span></div>
         </div>
         {% endif %}
@@ -206,6 +212,9 @@
       const isPie = spec.type === "pie";
       let labels = spec.labels;
       let counts = spec.counts;
+      // ラベルごとに元の並び順で色を固定し、棒・円で同じ選択肢が同色になるようにする
+      const colorByLabel = {};
+      spec.labels.forEach((label, i) => { colorByLabel[label] = palette[i % palette.length]; });
       if (isPie) {
         // 円グラフは割合（件数）の多い順に並べ替える
         const pairs = labels.map((label, i) => ({ label, count: counts[i] }));
@@ -213,7 +222,7 @@
         labels = pairs.map((p) => p.label);
         counts = pairs.map((p) => p.count);
       }
-      const colors = labels.map((_, i) => palette[i % palette.length]);
+      const colors = labels.map((label, i) => colorByLabel[label] || palette[i % palette.length]);
       return {
         type: spec.type,
         data: {
@@ -417,21 +426,35 @@
     function getCorrectMap() {
       const map = {};
       document.querySelectorAll("[data-correct-field]").forEach((container) => {
+        // 選択肢定義順（DOM順）で正解集合を作る
         const selected = Array.from(container.querySelectorAll(".js-correct-option"))
           .filter((o) => o.checked)
           .map((o) => o.value);
-        if (selected.length) map[container.dataset.correctField] = selected;
+        if (selected.length) {
+          const orderedEl = container.querySelector(".js-correct-ordered");
+          map[container.dataset.correctField] = {
+            set: selected,
+            ordered: !!(orderedEl && orderedEl.checked),
+          };
+        }
       });
       return map;
     }
 
-    function isRowCorrect(rowData, key, correctSet) {
+    function isRowCorrect(rowData, key, info) {
       const v = rowData[key];
       if (v === undefined || v === null) return false;
+      const correctSet = info.set;
       if (Array.isArray(v)) {
-        const a = v.map(String).sort();
-        const b = correctSet.slice().sort();
-        return a.length === b.length && a.every((x, i) => x === b[i]);
+        // 配列（複数選択）は過不足のない完全一致が必要
+        const a = v.map(String);
+        if (a.length !== correctSet.length) return false;
+        if (info.ordered) {
+          return a.every((x, i) => x === correctSet[i]);
+        }
+        const sa = a.slice().sort();
+        const sb = correctSet.slice().sort();
+        return sa.every((x, i) => x === sb[i]);
       }
       return correctSet.includes(String(v));
     }
@@ -457,6 +480,7 @@
       const rateEl = container.querySelector(".js-correct-rate");
       const total = parseFloat(rateEl.dataset.total) || 0;
       const options = Array.from(container.querySelectorAll(".js-correct-option"));
+      const orderedEl = container.querySelector(".js-correct-ordered");
 
       function recomputeField() {
         const selected = options.filter((o) => o.checked);
@@ -468,21 +492,35 @@
           rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + total + ")";
         }
         try {
-          localStorage.setItem(storageKey, JSON.stringify(selected.map((o) => o.value)));
+          localStorage.setItem(storageKey, JSON.stringify({
+            options: selected.map((o) => o.value),
+            ordered: orderedEl ? orderedEl.checked : false,
+          }));
         } catch (e) {}
       }
 
       try {
-        const saved = JSON.parse(localStorage.getItem(storageKey) || "[]");
+        const saved = JSON.parse(localStorage.getItem(storageKey) || "null");
+        let savedOptions = [];
+        let savedOrdered = false;
         if (Array.isArray(saved)) {
-          options.forEach((o) => { if (saved.includes(o.value)) o.checked = true; });
+          savedOptions = saved;
+        } else if (saved && typeof saved === "object") {
+          savedOptions = saved.options || [];
+          savedOrdered = !!saved.ordered;
         }
+        options.forEach((o) => { if (savedOptions.includes(o.value)) o.checked = true; });
+        if (orderedEl) orderedEl.checked = savedOrdered;
       } catch (e) {}
 
       options.forEach((o) => o.addEventListener("change", () => {
         recomputeField();
         recomputeRowRates();
       }));
+      if (orderedEl) orderedEl.addEventListener("change", () => {
+        recomputeField();
+        recomputeRowRates();
+      });
       recomputeField();
     });
 

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -50,13 +50,14 @@
           <canvas id="{{ canvas_id }}" class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.labels, 'counts': agg.counts, 'label': '件数', 'ckind': ('enum' if agg.is_enum else 'boolean'), 'field': agg.key, 'flabel': agg.label} | tojson_attr }}"></canvas>
         </div>
         {% if agg.supports_correct %}
-        <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}">
+        <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}" data-correct-array="{{ '1' if agg.is_array else '' }}">
           <div class="text-xs font-semibold text-slate-500">正解を指定</div>
           <div class="mt-2 flex flex-wrap gap-3 text-sm">
             {% for label in agg.labels %}
             <label class="inline-flex items-center gap-1">
               <input type="checkbox" class="js-correct-option" value="{{ label }}" data-count="{{ agg.counts[loop.index0] }}" />
               <span>{{ label }}</span>
+              {% if agg.is_array %}<sup class="js-order-badge font-semibold text-sky-600"></sup>{% endif %}
             </label>
             {% endfor %}
           </div>
@@ -426,17 +427,21 @@
     function getCorrectMap() {
       const map = {};
       document.querySelectorAll("[data-correct-field]").forEach((container) => {
-        // 選択肢定義順（DOM順）で正解集合を作る
-        const selected = Array.from(container.querySelectorAll(".js-correct-option"))
+        const checked = Array.from(container.querySelectorAll(".js-correct-option"))
           .filter((o) => o.checked)
           .map((o) => o.value);
-        if (selected.length) {
-          const orderedEl = container.querySelector(".js-correct-ordered");
-          map[container.dataset.correctField] = {
-            set: selected,
-            ordered: !!(orderedEl && orderedEl.checked),
-          };
-        }
+        if (!checked.length) return;
+        // チェックを付けた順番（data-correct-order）を正解の並び順として採用する
+        let order = [];
+        try { order = JSON.parse(container.dataset.correctOrder || "[]"); } catch (e) {}
+        const checkedSet = new Set(checked);
+        const set = order.filter((v) => checkedSet.has(v));
+        checked.forEach((v) => { if (!set.includes(v)) set.push(v); });
+        const orderedEl = container.querySelector(".js-correct-ordered");
+        map[container.dataset.correctField] = {
+          set: set,
+          ordered: !!(orderedEl && orderedEl.checked),
+        };
       });
       return map;
     }
@@ -481,19 +486,62 @@
       const total = parseFloat(rateEl.dataset.total) || 0;
       const options = Array.from(container.querySelectorAll(".js-correct-option"));
       const orderedEl = container.querySelector(".js-correct-ordered");
+      const fieldKey = container.dataset.correctField;
+      const isArrayField = container.dataset.correctArray === "1";
+      let checkOrder = [];
+
+      function syncCheckOrder() {
+        // チェックされている値を、付けた順番を保ったまま保持する
+        const checkedValues = options.filter((o) => o.checked).map((o) => o.value);
+        checkOrder = checkOrder.filter((v) => checkedValues.includes(v));
+        checkedValues.forEach((v) => { if (!checkOrder.includes(v)) checkOrder.push(v); });
+        container.dataset.correctOrder = JSON.stringify(checkOrder);
+      }
+
+      function updateBadges() {
+        const showOrder = isArrayField && orderedEl && orderedEl.checked;
+        options.forEach((o) => {
+          const badge = o.closest("label").querySelector(".js-order-badge");
+          if (!badge) return;
+          if (showOrder && o.checked) {
+            const idx = checkOrder.indexOf(o.value);
+            badge.textContent = idx >= 0 ? String(idx + 1) : "";
+          } else {
+            badge.textContent = "";
+          }
+        });
+      }
 
       function recomputeField() {
-        const selected = options.filter((o) => o.checked);
-        if (selected.length === 0) {
+        syncCheckOrder();
+        updateBadges();
+        const selectedValues = checkOrder.slice();
+        if (selectedValues.length === 0) {
           rateEl.textContent = "—";
+        } else if (isArrayField) {
+          // 配列(複数選択)は延べ選択数ではなく、行単位の完全一致で正答した
+          // 送信数を数え、回答済み件数で割る（表の行単位と一致させる）
+          const info = { set: selectedValues, ordered: orderedEl ? orderedEl.checked : false };
+          let answered = 0;
+          let correct = 0;
+          tableRows.forEach((row) => {
+            const v = row.data[fieldKey];
+            const hasAnswer = Array.isArray(v) ? v.length > 0 : (v !== undefined && v !== null && v !== "");
+            if (!hasAnswer) return;
+            answered += 1;
+            if (isRowCorrect(row.data, fieldKey, info)) correct += 1;
+          });
+          const rate = answered > 0 ? (correct / answered * 100) : 0;
+          rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + answered + ")";
         } else {
-          const correct = selected.reduce((acc, o) => acc + (parseFloat(o.dataset.count) || 0), 0);
+          const correct = options.filter((o) => o.checked)
+            .reduce((acc, o) => acc + (parseFloat(o.dataset.count) || 0), 0);
           const rate = total > 0 ? (correct / total * 100) : 0;
           rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + total + ")";
         }
         try {
           localStorage.setItem(storageKey, JSON.stringify({
-            options: selected.map((o) => o.value),
+            options: selectedValues,
             ordered: orderedEl ? orderedEl.checked : false,
           }));
         } catch (e) {}
@@ -509,7 +557,13 @@
           savedOptions = saved.options || [];
           savedOrdered = !!saved.ordered;
         }
-        options.forEach((o) => { if (savedOptions.includes(o.value)) o.checked = true; });
+        const validValues = options.map((o) => o.value);
+        savedOptions.forEach((v) => {
+          const opt = options.find((o) => o.value === v);
+          if (opt) opt.checked = true;
+        });
+        // 保存された並び順をチェック順として復元する
+        checkOrder = savedOptions.filter((v) => validValues.includes(v));
         if (orderedEl) orderedEl.checked = savedOrdered;
       } catch (e) {}
 

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -204,14 +204,23 @@
     function buildConfig(spec) {
       const isLine = spec.type === "line";
       const isPie = spec.type === "pie";
-      const colors = spec.labels.map((_, i) => palette[i % palette.length]);
+      let labels = spec.labels;
+      let counts = spec.counts;
+      if (isPie) {
+        // 円グラフは割合（件数）の多い順に並べ替える
+        const pairs = labels.map((label, i) => ({ label, count: counts[i] }));
+        pairs.sort((a, b) => b.count - a.count);
+        labels = pairs.map((p) => p.label);
+        counts = pairs.map((p) => p.count);
+      }
+      const colors = labels.map((_, i) => palette[i % palette.length]);
       return {
         type: spec.type,
         data: {
-          labels: spec.labels,
+          labels: labels,
           datasets: [{
             label: spec.label || "",
-            data: spec.counts,
+            data: counts,
             backgroundColor: isLine ? "rgba(37, 99, 235, 0.2)" : colors,
             borderColor: isLine ? "#2563eb" : colors,
             borderWidth: isLine ? 2 : 1,
@@ -223,9 +232,9 @@
           responsive: true,
           maintainAspectRatio: false,
           interaction: isPie ? undefined : { mode: "index", intersect: false },
-          onClick: (evt, elements) => {
+          onClick: (evt, elements, chart) => {
             if (!elements.length) return;
-            applyDrill(spec, elements[0].index);
+            applyDrill(spec, elements[0].index, chart);
           },
           plugins: {
             legend: { display: isPie },
@@ -265,13 +274,15 @@
     });
 
     // ---- グラフクリックによる絞り込み（ドリルダウン） ----
-    function buildPredicate(spec, index) {
+    function buildPredicate(spec, index, chart) {
+      // 円グラフは並べ替えるため、クリックされたラベルはチャート本体から取得する
+      const clickedLabel = chart ? chart.data.labels[index] : spec.labels[index];
       if (spec.ckind === "date") {
-        const day = spec.labels[index];
+        const day = clickedLabel;
         return { label: spec.flabel + ": " + day, test: (row) => row.date === day };
       }
       if (spec.ckind === "enum") {
-        const target = spec.labels[index];
+        const target = clickedLabel;
         return {
           label: spec.flabel + ": " + target,
           test: (row) => {
@@ -282,9 +293,9 @@
         };
       }
       if (spec.ckind === "boolean") {
-        const target = spec.labels[index] === "true";
+        const target = clickedLabel === "true";
         return {
-          label: spec.flabel + ": " + spec.labels[index],
+          label: spec.flabel + ": " + clickedLabel,
           test: (row) => toBool(row.data[spec.field]) === target,
         };
       }
@@ -309,8 +320,8 @@
       return null;
     }
 
-    function applyDrill(spec, index) {
-      const predicate = buildPredicate(spec, index);
+    function applyDrill(spec, index, chart) {
+      const predicate = buildPredicate(spec, index, chart);
       if (!predicate) return;
       let count = 0;
       tableRows.forEach((row) => {

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -49,8 +49,9 @@
   <div class="mt-6 rounded-lg border border-slate-200 bg-white px-4 py-10 text-center text-slate-500">該当データがありません。</div>
   {% else %}
 
+  <div class="mt-6 grid gap-4 lg:grid-cols-2">
   {% if timeseries_timestamps %}
-  <div id="timeseries-section" class="mt-6 rounded-lg border border-slate-200 bg-white p-4" data-timestamps="{{ timeseries_timestamps | tojson_attr }}">
+  <div id="timeseries-section" class="rounded-lg border border-slate-200 bg-white p-4" data-timestamps="{{ timeseries_timestamps | tojson_attr }}">
     <div class="flex flex-wrap items-center justify-between gap-2">
       <h2 class="text-base font-semibold text-slate-900">件数の推移</h2>
       <label class="flex items-center gap-1 text-xs text-slate-500">
@@ -74,7 +75,6 @@
   </div>
   {% endif %}
 
-  <div class="mt-6 grid gap-4 lg:grid-cols-2">
     {% for agg in aggregations %}
     {% set canvas_id = 'chart-' ~ loop.index0 %}
     <div class="rounded-lg border border-slate-200 bg-white p-4">
@@ -143,14 +143,14 @@
       {% endif %}
     </div>
     {% endfor %}
-  </div>
 
-  <div id="correct-dist-section" class="mt-6 hidden rounded-lg border border-slate-200 bg-white p-4">
-    <h2 class="text-base font-semibold text-slate-900">正答数の分布</h2>
-    <div class="relative mt-3 h-64">
-      <canvas id="correct-dist-chart"></canvas>
+    <div id="correct-dist-section" class="hidden rounded-lg border border-slate-200 bg-white p-4">
+      <h2 class="text-base font-semibold text-slate-900">正答数の分布</h2>
+      <div class="relative mt-3 h-64">
+        <canvas id="correct-dist-chart"></canvas>
+      </div>
+      <p class="mt-2 text-xs text-slate-400">正解を指定すると表示されます。グラフをクリックすると、その正答数の送信のみ表に表示します。</p>
     </div>
-    <p class="mt-2 text-xs text-slate-400">正解を指定すると表示されます。グラフをクリックすると、その正答数の送信のみ表に表示します。</p>
   </div>
 
   <div id="data-table-section" class="mt-8">
@@ -379,6 +379,8 @@
         counts = pairs.map((p) => p.count);
       }
       const colors = labels.map((label, i) => colorByLabel[label] || palette[i % palette.length]);
+      const fill = isLine ? "rgba(37, 99, 235, 0.2)" : (spec.mono ? palette[0] : colors);
+      const stroke = isLine ? "#2563eb" : (spec.mono ? palette[0] : colors);
       return {
         type: spec.type,
         data: {
@@ -386,8 +388,8 @@
           datasets: [{
             label: spec.label || "",
             data: counts,
-            backgroundColor: isLine ? "rgba(37, 99, 235, 0.2)" : colors,
-            borderColor: isLine ? "#2563eb" : colors,
+            backgroundColor: fill,
+            borderColor: stroke,
             borderWidth: isLine ? 2 : 1,
             fill: isLine,
             tension: isLine ? 0.2 : 0,
@@ -761,7 +763,7 @@
         counts[correct] += 1;
       });
       const labels = counts.map((_, i) => String(i));
-      const spec = { type: "bar", labels, counts, label: "件数", ckind: "correctcount", flabel: "正答数" };
+      const spec = { type: "bar", labels, counts, label: "件数", ckind: "correctcount", flabel: "正答数", mono: true };
       correctDistSection.classList.remove("hidden");
       if (correctDistChart) correctDistChart.destroy();
       correctDistChart = new Chart(correctDistCanvas, buildConfig(spec));

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_file_preview.html" import file_value as render_file_value %}
 {% block content %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 
@@ -21,8 +22,9 @@
   <div class="mt-6 rounded-lg border border-slate-200 bg-white p-4">
     <h2 class="text-base font-semibold text-slate-900">日付別の件数推移</h2>
     <div class="relative mt-3 h-64">
-      <canvas class="js-chart" data-chart="{{ {'type': 'line', 'labels': timeseries.labels, 'counts': timeseries.counts, 'label': '件数'} | tojson_attr }}"></canvas>
+      <canvas class="js-chart" data-chart="{{ {'type': 'line', 'labels': timeseries.labels, 'counts': timeseries.counts, 'label': '件数', 'ckind': 'date', 'flabel': '送信日'} | tojson_attr }}"></canvas>
     </div>
+    <p class="mt-2 text-xs text-slate-400">グラフをクリックすると、下の表に該当データのみを表示します。</p>
   </div>
   {% endif %}
 
@@ -45,7 +47,7 @@
         <p class="mt-3 text-sm text-slate-500">データなし</p>
         {% else %}
         <div class="relative mt-3 h-64">
-          <canvas id="{{ canvas_id }}" class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.labels, 'counts': agg.counts, 'label': '件数'} | tojson_attr }}"></canvas>
+          <canvas id="{{ canvas_id }}" class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.labels, 'counts': agg.counts, 'label': '件数', 'ckind': ('enum' if agg.is_enum else 'boolean'), 'field': agg.key, 'flabel': agg.label} | tojson_attr }}"></canvas>
         </div>
         {% if agg.supports_correct %}
         <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}">
@@ -74,12 +76,91 @@
         </table>
         {% if agg.histogram.labels %}
         <div class="relative mt-3 h-64">
-          <canvas class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.histogram.labels, 'counts': agg.histogram.counts, 'label': '件数'} | tojson_attr }}"></canvas>
+          <canvas class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.histogram.labels, 'counts': agg.histogram.counts, 'label': '件数', 'ckind': 'numeric', 'field': agg.key, 'flabel': agg.label, 'ranges': agg.histogram.ranges, 'mode': agg.histogram.mode} | tojson_attr }}"></canvas>
         </div>
         {% endif %}
       {% endif %}
     </div>
     {% endfor %}
+  </div>
+
+  <div id="data-table-section" class="mt-8">
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <h2 class="text-lg font-semibold text-slate-900">元データ</h2>
+      <div id="drill-banner" class="hidden items-center gap-2 rounded border border-sky-200 bg-sky-50 px-3 py-1.5 text-sm text-sky-800">
+        <span>絞り込み中: <span id="drill-label" class="font-semibold"></span>（<span id="drill-count"></span>件）</span>
+        <button type="button" id="drill-clear" class="rounded border border-sky-300 px-2 py-0.5 text-xs">解除</button>
+      </div>
+    </div>
+
+    <div class="mt-3 overflow-x-auto rounded-lg border border-slate-200 bg-white">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-100 text-left">
+          <tr>
+            <th class="px-4 py-3">送信日時</th>
+            <th class="px-4 py-3">送信ユーザー</th>
+            <th class="px-4 py-3">正答率</th>
+            {% for column in display_columns %}
+            <th class="px-4 py-3">{{ column.label }}</th>
+            {% endfor %}
+            <th class="px-4 py-3">操作</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-200">
+          {% for row in rows %}
+          <tr data-row="{{ row.drill | tojson_attr }}" data-date="{{ row.date }}">
+            <td class="px-4 py-3 text-slate-600">
+              <time class="js-local-dt" data-iso="{{ iso_dt(row.created_at) }}">{{ format_dt(row.created_at) }}</time>
+            </td>
+            <td class="px-4 py-3 text-slate-600">{{ row.username or '-' }}</td>
+            <td class="px-4 py-3 text-slate-700"><span class="js-row-rate tabular-nums">—</span></td>
+            {% for value in row["values"] %}
+            {% set column = display_columns[loop.index0] %}
+            {% set raw_value = row.raw_values[loop.index0] if row.raw_values is defined else none %}
+            {% if column.kind == "default" and column.field.type == "file" and raw_value %}
+              <td class="px-4 py-3">{{ render_file_value(raw_value, file_infos, "sm") }}</td>
+            {% elif column.kind == "master_display" and column.display_type == "file" and raw_value %}
+              <td class="px-4 py-3">{{ render_file_value(raw_value, file_infos, "sm") }}</td>
+            {% elif column.kind == "default"
+                  and column.field.type == "string"
+                  and (
+                    column.field.format == "url"
+                    or "http://" in value
+                    or "https://" in value
+                    or "www." in value
+                  )
+                  and value %}
+              <td class="px-4 py-3">
+                {% set raw_items = value.split(",") if column.field.is_array else [value] %}
+                {% for raw_item in raw_items %}
+                  {% set trimmed = raw_item | trim %}
+                  {% if trimmed %}
+                    {% if trimmed.startswith("http://") or trimmed.startswith("https://") %}
+                      <a href="{{ trimmed }}" target="_blank" rel="noopener noreferrer" class="break-all text-sky-700 underline">{{ trimmed }}</a>
+                    {% elif trimmed.startswith("www.") %}
+                      <a href="https://{{ trimmed }}" target="_blank" rel="noopener noreferrer" class="break-all text-sky-700 underline">{{ trimmed }}</a>
+                    {% else %}
+                      {{ trimmed }}
+                    {% endif %}
+                    {% if not loop.last %}, {% endif %}
+                  {% endif %}
+                {% endfor %}
+              </td>
+            {% else %}
+            <td class="px-4 py-3">{{ value }}</td>
+            {% endif %}
+            {% endfor %}
+            <td class="px-4 py-3">
+              <a href="/forms/{{ form.id }}/submissions/{{ row.id }}/edit" class="whitespace-nowrap rounded border border-slate-300 px-2 py-1 text-xs text-slate-700">詳細</a>
+            </td>
+          </tr>
+          {% endfor %}
+          <tr id="drill-empty-row" class="hidden">
+            <td colspan="{{ display_columns | length + 4 }}" class="px-4 py-6 text-center text-slate-500">該当データがありません。</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
   {% endif %}
 </div>
@@ -95,6 +176,21 @@
       "#db2777", "#65a30d", "#ea580c", "#4f46e5", "#0d9488", "#9333ea",
     ];
     const charts = {};
+
+    const tableRows = Array.from(document.querySelectorAll("tr[data-row]")).map((tr) => {
+      let data = {};
+      try { data = JSON.parse(tr.dataset.row); } catch (e) {}
+      return { tr, data, date: tr.dataset.date || "", rateCell: tr.querySelector(".js-row-rate") };
+    });
+    const emptyRow = document.getElementById("drill-empty-row");
+    const banner = document.getElementById("drill-banner");
+    const drillLabel = document.getElementById("drill-label");
+    const drillCount = document.getElementById("drill-count");
+
+    function toBool(value) {
+      if (Array.isArray(value)) value = value[0];
+      return value === true || (typeof value === "string" && ["true", "1", "yes", "on"].includes(value.toLowerCase()));
+    }
 
     function buildConfig(spec) {
       const isLine = spec.type === "line";
@@ -117,6 +213,11 @@
         options: {
           responsive: true,
           maintainAspectRatio: false,
+          interaction: isPie ? undefined : { mode: "index", intersect: false },
+          onClick: (evt, elements) => {
+            if (!elements.length) return;
+            applyDrill(spec, elements[0].index);
+          },
           plugins: { legend: { display: isPie } },
           scales: isPie ? {} : { y: { beginAtZero: true, ticks: { precision: 0 } } },
         },
@@ -125,11 +226,7 @@
 
     document.querySelectorAll("canvas.js-chart").forEach((canvas) => {
       let spec;
-      try {
-        spec = JSON.parse(canvas.dataset.chart);
-      } catch (e) {
-        return;
-      }
+      try { spec = JSON.parse(canvas.dataset.chart); } catch (e) { return; }
       const chart = new Chart(canvas, buildConfig(spec));
       if (canvas.id) charts[canvas.id] = { chart, spec };
     });
@@ -140,28 +237,138 @@
         if (!entry) return;
         entry.chart.destroy();
         const nextSpec = Object.assign({}, entry.spec, { type: button.dataset.mode });
-        entry.chart = new Chart(
-          document.getElementById(button.dataset.target),
-          buildConfig(nextSpec),
-        );
+        entry.chart = new Chart(document.getElementById(button.dataset.target), buildConfig(nextSpec));
         entry.spec = nextSpec;
       });
     });
 
+    // ---- グラフクリックによる絞り込み（ドリルダウン） ----
+    function buildPredicate(spec, index) {
+      if (spec.ckind === "date") {
+        const day = spec.labels[index];
+        return { label: spec.flabel + ": " + day, test: (row) => row.date === day };
+      }
+      if (spec.ckind === "enum") {
+        const target = spec.labels[index];
+        return {
+          label: spec.flabel + ": " + target,
+          test: (row) => {
+            const v = row.data[spec.field];
+            if (Array.isArray(v)) return v.map(String).includes(target);
+            return String(v) === target;
+          },
+        };
+      }
+      if (spec.ckind === "boolean") {
+        const target = spec.labels[index] === "true";
+        return {
+          label: spec.flabel + ": " + spec.labels[index],
+          test: (row) => toBool(row.data[spec.field]) === target,
+        };
+      }
+      if (spec.ckind === "numeric") {
+        const range = spec.ranges[index];
+        const isLast = index === spec.ranges.length - 1;
+        const exact = spec.mode === "exact";
+        return {
+          label: spec.flabel + ": " + spec.labels[index],
+          test: (row) => {
+            let v = row.data[spec.field];
+            const arr = Array.isArray(v) ? v : [v];
+            return arr.some((x) => {
+              const n = Number(x);
+              if (Number.isNaN(n)) return false;
+              if (exact) return n === range[0];
+              return n >= range[0] && (isLast ? n <= range[1] : n < range[1]);
+            });
+          },
+        };
+      }
+      return null;
+    }
+
+    function applyDrill(spec, index) {
+      const predicate = buildPredicate(spec, index);
+      if (!predicate) return;
+      let count = 0;
+      tableRows.forEach((row) => {
+        const ok = predicate.test(row);
+        row.tr.classList.toggle("hidden", !ok);
+        if (ok) count += 1;
+      });
+      if (emptyRow) emptyRow.classList.toggle("hidden", count > 0);
+      if (banner) {
+        banner.classList.remove("hidden");
+        banner.classList.add("flex");
+        drillLabel.textContent = predicate.label;
+        drillCount.textContent = count;
+      }
+      const section = document.getElementById("data-table-section");
+      if (section) section.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    function clearDrill() {
+      tableRows.forEach((row) => row.tr.classList.remove("hidden"));
+      if (emptyRow) emptyRow.classList.add("hidden");
+      if (banner) {
+        banner.classList.add("hidden");
+        banner.classList.remove("flex");
+      }
+    }
+
+    document.getElementById("drill-clear")?.addEventListener("click", clearDrill);
+
+    // ---- 各送信ごとの正答率 ----
+    function getCorrectMap() {
+      const map = {};
+      document.querySelectorAll("[data-correct-field]").forEach((container) => {
+        const selected = Array.from(container.querySelectorAll(".js-correct-option"))
+          .filter((o) => o.checked)
+          .map((o) => o.value);
+        if (selected.length) map[container.dataset.correctField] = selected;
+      });
+      return map;
+    }
+
+    function isRowCorrect(rowData, key, correctSet) {
+      const v = rowData[key];
+      if (v === undefined || v === null) return false;
+      if (Array.isArray(v)) {
+        const a = v.map(String).sort();
+        const b = correctSet.slice().sort();
+        return a.length === b.length && a.every((x, i) => x === b[i]);
+      }
+      return correctSet.includes(String(v));
+    }
+
+    function recomputeRowRates() {
+      const correctMap = getCorrectMap();
+      const keys = Object.keys(correctMap);
+      tableRows.forEach((row) => {
+        if (!row.rateCell) return;
+        if (!keys.length) { row.rateCell.textContent = "—"; return; }
+        let correct = 0;
+        keys.forEach((key) => {
+          if (isRowCorrect(row.data, key, correctMap[key])) correct += 1;
+        });
+        const rate = (correct / keys.length) * 100;
+        row.rateCell.textContent = rate.toFixed(0) + "% (" + correct + "/" + keys.length + ")";
+      });
+    }
+
+    // ---- 設問ごとの正答率（円/棒の下の表示）と localStorage 復元 ----
     document.querySelectorAll("[data-correct-field]").forEach((container) => {
       const storageKey = "sf-correct:" + formId + ":" + container.dataset.correctField;
       const rateEl = container.querySelector(".js-correct-rate");
       const total = parseFloat(rateEl.dataset.total) || 0;
       const options = Array.from(container.querySelectorAll(".js-correct-option"));
 
-      function recompute() {
+      function recomputeField() {
         const selected = options.filter((o) => o.checked);
         if (selected.length === 0) {
           rateEl.textContent = "—";
         } else {
-          const correct = selected.reduce(
-            (acc, o) => acc + (parseFloat(o.dataset.count) || 0), 0,
-          );
+          const correct = selected.reduce((acc, o) => acc + (parseFloat(o.dataset.count) || 0), 0);
           const rate = total > 0 ? (correct / total * 100) : 0;
           rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + total + ")";
         }
@@ -177,9 +384,14 @@
         }
       } catch (e) {}
 
-      options.forEach((o) => o.addEventListener("change", recompute));
-      recompute();
+      options.forEach((o) => o.addEventListener("change", () => {
+        recomputeField();
+        recomputeRowRates();
+      }));
+      recomputeField();
     });
+
+    recomputeRowRates();
   });
 </script>
 {% endblock %}

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -154,13 +154,13 @@
 
   <div id="data-table-section" class="mt-8">
     <div class="flex flex-wrap items-center justify-between gap-2">
-      <div class="flex items-center gap-3">
-        <h2 class="text-lg font-semibold text-slate-900">元データ</h2>
+      <h2 class="text-lg font-semibold text-slate-900">元データ</h2>
+      <div class="flex flex-wrap items-center gap-2">
+        <div id="drill-banner" class="hidden items-center gap-2 rounded border border-sky-200 bg-sky-50 px-3 py-1.5 text-sm text-sky-800">
+          <span>絞り込み中: <span id="drill-label" class="font-semibold"></span>（<span id="drill-count"></span>件）</span>
+          <button type="button" id="drill-clear" class="rounded border border-sky-300 px-2 py-0.5 text-xs">解除</button>
+        </div>
         <button type="button" id="open-download-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">ダウンロード</button>
-      </div>
-      <div id="drill-banner" class="hidden items-center gap-2 rounded border border-sky-200 bg-sky-50 px-3 py-1.5 text-sm text-sky-800">
-        <span>絞り込み中: <span id="drill-label" class="font-semibold"></span>（<span id="drill-count"></span>件）</span>
-        <button type="button" id="drill-clear" class="rounded border border-sky-300 px-2 py-0.5 text-xs">解除</button>
       </div>
     </div>
 

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -10,7 +10,6 @@
       <p class="text-sm text-slate-600">{{ form.name }} の送信内容を集計します。</p>
     </div>
     <div class="flex gap-2">
-      <button type="button" id="open-download-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">ダウンロード</button>
       <a href="/forms/{{ form.id }}/submissions?{{ build_query(query, page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">送信一覧へ戻る</a>
     </div>
   </div>
@@ -155,7 +154,10 @@
 
   <div id="data-table-section" class="mt-8">
     <div class="flex flex-wrap items-center justify-between gap-2">
-      <h2 class="text-lg font-semibold text-slate-900">元データ</h2>
+      <div class="flex items-center gap-3">
+        <h2 class="text-lg font-semibold text-slate-900">元データ</h2>
+        <button type="button" id="open-download-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">ダウンロード</button>
+      </div>
       <div id="drill-banner" class="hidden items-center gap-2 rounded border border-sky-200 bg-sky-50 px-3 py-1.5 text-sm text-sky-800">
         <span>絞り込み中: <span id="drill-label" class="font-semibold"></span>（<span id="drill-count"></span>件）</span>
         <button type="button" id="drill-clear" class="rounded border border-sky-300 px-2 py-0.5 text-xs">解除</button>

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -1,0 +1,185 @@
+{% extends "base.html" %}
+{% block content %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+
+<div id="aggregate-root" data-form-id="{{ form.id }}">
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-2xl font-semibold">集計</h1>
+      <p class="text-sm text-slate-600">{{ form.name }} の送信内容を集計します（対象 {{ total_submissions }} 件）。</p>
+    </div>
+    <div class="flex gap-2">
+      <a href="/forms/{{ form.id }}/submissions?{{ build_query(query, page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">送信一覧へ戻る</a>
+    </div>
+  </div>
+
+  {% if total_submissions == 0 %}
+  <div class="mt-6 rounded-lg border border-slate-200 bg-white px-4 py-10 text-center text-slate-500">該当データがありません。</div>
+  {% else %}
+
+  {% if timeseries.labels %}
+  <div class="mt-6 rounded-lg border border-slate-200 bg-white p-4">
+    <h2 class="text-base font-semibold text-slate-900">日付別の件数推移</h2>
+    <div class="relative mt-3 h-64">
+      <canvas class="js-chart" data-chart="{{ {'type': 'line', 'labels': timeseries.labels, 'counts': timeseries.counts, 'label': '件数'} | tojson_attr }}"></canvas>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="mt-6 grid gap-4 lg:grid-cols-2">
+    {% for agg in aggregations %}
+    {% set canvas_id = 'chart-' ~ loop.index0 %}
+    <div class="rounded-lg border border-slate-200 bg-white p-4">
+      <div class="flex items-center justify-between gap-2">
+        <h2 class="text-base font-semibold text-slate-900">{{ agg.label }}</h2>
+        {% if agg.kind == 'distribution' %}
+        <div class="flex gap-1 text-xs">
+          <button type="button" class="js-chart-toggle rounded border border-slate-300 px-2 py-1" data-target="{{ canvas_id }}" data-mode="bar">棒</button>
+          <button type="button" class="js-chart-toggle rounded border border-slate-300 px-2 py-1" data-target="{{ canvas_id }}" data-mode="pie">円</button>
+        </div>
+        {% endif %}
+      </div>
+
+      {% if agg.kind == 'distribution' %}
+        {% if agg.total == 0 %}
+        <p class="mt-3 text-sm text-slate-500">データなし</p>
+        {% else %}
+        <div class="relative mt-3 h-64">
+          <canvas id="{{ canvas_id }}" class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.labels, 'counts': agg.counts, 'label': '件数'} | tojson_attr }}"></canvas>
+        </div>
+        {% if agg.supports_correct %}
+        <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}">
+          <div class="text-xs font-semibold text-slate-500">正解を指定</div>
+          <div class="mt-2 flex flex-wrap gap-3 text-sm">
+            {% for label in agg.labels %}
+            <label class="inline-flex items-center gap-1">
+              <input type="checkbox" class="js-correct-option" value="{{ label }}" data-count="{{ agg.counts[loop.index0] }}" />
+              <span>{{ label }}</span>
+            </label>
+            {% endfor %}
+          </div>
+          <div class="mt-2 text-sm text-slate-700">正答率: <span class="js-correct-rate font-semibold" data-total="{{ agg.total }}">—</span></div>
+        </div>
+        {% endif %}
+        {% endif %}
+      {% elif agg.kind == 'numeric' %}
+        <table class="mt-3 w-full text-sm">
+          <tbody class="divide-y divide-slate-100">
+            <tr><td class="py-1 text-slate-500">件数</td><td class="py-1 text-right tabular-nums">{{ agg.stats.count }}</td></tr>
+            <tr><td class="py-1 text-slate-500">合計</td><td class="py-1 text-right tabular-nums">{{ agg.stats.sum }}</td></tr>
+            <tr><td class="py-1 text-slate-500">平均</td><td class="py-1 text-right tabular-nums">{{ agg.stats.avg }}</td></tr>
+            <tr><td class="py-1 text-slate-500">最大</td><td class="py-1 text-right tabular-nums">{{ agg.stats.max }}</td></tr>
+            <tr><td class="py-1 text-slate-500">最小</td><td class="py-1 text-right tabular-nums">{{ agg.stats.min }}</td></tr>
+          </tbody>
+        </table>
+        {% if agg.histogram.labels %}
+        <div class="relative mt-3 h-64">
+          <canvas class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.histogram.labels, 'counts': agg.histogram.counts, 'label': '件数'} | tojson_attr }}"></canvas>
+        </div>
+        {% endif %}
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    if (typeof Chart === "undefined") return;
+
+    const root = document.getElementById("aggregate-root");
+    const formId = root ? root.dataset.formId : "";
+    const palette = [
+      "#2563eb", "#16a34a", "#dc2626", "#d97706", "#7c3aed", "#0891b2",
+      "#db2777", "#65a30d", "#ea580c", "#4f46e5", "#0d9488", "#9333ea",
+    ];
+    const charts = {};
+
+    function buildConfig(spec) {
+      const isLine = spec.type === "line";
+      const isPie = spec.type === "pie";
+      const colors = spec.labels.map((_, i) => palette[i % palette.length]);
+      return {
+        type: spec.type,
+        data: {
+          labels: spec.labels,
+          datasets: [{
+            label: spec.label || "",
+            data: spec.counts,
+            backgroundColor: isLine ? "rgba(37, 99, 235, 0.2)" : colors,
+            borderColor: isLine ? "#2563eb" : colors,
+            borderWidth: isLine ? 2 : 1,
+            fill: isLine,
+            tension: isLine ? 0.2 : 0,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { legend: { display: isPie } },
+          scales: isPie ? {} : { y: { beginAtZero: true, ticks: { precision: 0 } } },
+        },
+      };
+    }
+
+    document.querySelectorAll("canvas.js-chart").forEach((canvas) => {
+      let spec;
+      try {
+        spec = JSON.parse(canvas.dataset.chart);
+      } catch (e) {
+        return;
+      }
+      const chart = new Chart(canvas, buildConfig(spec));
+      if (canvas.id) charts[canvas.id] = { chart, spec };
+    });
+
+    document.querySelectorAll(".js-chart-toggle").forEach((button) => {
+      button.addEventListener("click", () => {
+        const entry = charts[button.dataset.target];
+        if (!entry) return;
+        entry.chart.destroy();
+        const nextSpec = Object.assign({}, entry.spec, { type: button.dataset.mode });
+        entry.chart = new Chart(
+          document.getElementById(button.dataset.target),
+          buildConfig(nextSpec),
+        );
+        entry.spec = nextSpec;
+      });
+    });
+
+    document.querySelectorAll("[data-correct-field]").forEach((container) => {
+      const storageKey = "sf-correct:" + formId + ":" + container.dataset.correctField;
+      const rateEl = container.querySelector(".js-correct-rate");
+      const total = parseFloat(rateEl.dataset.total) || 0;
+      const options = Array.from(container.querySelectorAll(".js-correct-option"));
+
+      function recompute() {
+        const selected = options.filter((o) => o.checked);
+        if (selected.length === 0) {
+          rateEl.textContent = "—";
+        } else {
+          const correct = selected.reduce(
+            (acc, o) => acc + (parseFloat(o.dataset.count) || 0), 0,
+          );
+          const rate = total > 0 ? (correct / total * 100) : 0;
+          rateEl.textContent = rate.toFixed(1) + "% (" + correct + "/" + total + ")";
+        }
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(selected.map((o) => o.value)));
+        } catch (e) {}
+      }
+
+      try {
+        const saved = JSON.parse(localStorage.getItem(storageKey) || "[]");
+        if (Array.isArray(saved)) {
+          options.forEach((o) => { if (saved.includes(o.value)) o.checked = true; });
+        }
+      } catch (e) {}
+
+      options.forEach((o) => o.addEventListener("change", recompute));
+      recompute();
+    });
+  });
+</script>
+{% endblock %}

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -7,7 +7,7 @@
   <div class="flex flex-wrap items-center justify-between gap-3">
     <div>
       <h1 class="text-2xl font-semibold">集計</h1>
-      <p class="text-sm text-slate-600">{{ form.name }} の送信内容を集計します（対象 {{ total_submissions }} 件）。</p>
+      <p class="text-sm text-slate-600">{{ form.name }} の送信内容を集計します。</p>
     </div>
     <div class="flex gap-2">
       <a href="/forms/{{ form.id }}/submissions?{{ build_query(query, page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">送信一覧へ戻る</a>

--- a/templates/aggregate.html
+++ b/templates/aggregate.html
@@ -50,28 +50,25 @@
           <canvas id="{{ canvas_id }}" class="js-chart" data-chart="{{ {'type': 'bar', 'labels': agg.labels, 'counts': agg.counts, 'label': '件数', 'ckind': ('enum' if agg.is_enum else 'boolean'), 'field': agg.key, 'flabel': agg.label} | tojson_attr }}"></canvas>
         </div>
         {% if agg.supports_correct %}
-        <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}" data-correct-array="{{ '1' if agg.is_array else '' }}">
+        <div class="mt-3 border-t border-slate-100 pt-3" data-correct-field="{{ agg.key }}" data-correct-array="{{ '1' if agg.is_array else '' }}" data-correct-unique="{{ '1' if agg.unique_items else '' }}">
           <div class="text-xs font-semibold text-slate-500">正解</div>
           {% if agg.is_array %}
-          <div class="js-correct-rows mt-2 space-y-2"></div>
-          <button type="button" class="js-correct-add mt-1 rounded border border-slate-300 px-3 py-1 text-xs">追加</button>
-          <template class="js-correct-row-template">
-            <div class="flex items-center gap-2 js-correct-row">
-              <select class="js-correct-select w-full max-w-xs rounded border border-slate-300 px-2 py-1 text-sm">
-                <option value="">選択してください</option>
-                {% for label in agg.labels %}
-                <option value="{{ label }}">{{ label }}</option>
-                {% endfor %}
-              </select>
-              <button type="button" class="js-correct-remove shrink-0 whitespace-nowrap rounded border border-rose-300 px-2 py-1 text-xs text-rose-600">削除</button>
-            </div>
-          </template>
+          <div class="mt-2 flex items-center gap-2">
+            <select class="js-correct-add-select w-full max-w-xs rounded border border-slate-300 px-2 py-2 text-sm">
+              <option value="">選択してください</option>
+              {% for label in agg.labels %}
+              <option value="{{ label }}">{{ label }}</option>
+              {% endfor %}
+            </select>
+            <button type="button" class="js-correct-add shrink-0 rounded border border-slate-300 px-3 py-2 text-sm">追加</button>
+          </div>
+          <div class="js-correct-badges mt-2 flex flex-wrap gap-2"></div>
           <label class="mt-2 inline-flex items-center gap-1 text-xs text-slate-500">
             <input type="checkbox" class="js-correct-ordered" />
             <span>順番も一致させる</span>
           </label>
           {% else %}
-          <select class="js-correct-single mt-2 w-full max-w-xs rounded border border-slate-300 px-2 py-1 text-sm">
+          <select class="js-correct-single mt-2 w-full max-w-xs rounded border border-slate-300 px-2 py-2 text-sm">
             <option value="">指定なし</option>
             {% for label in agg.labels %}
             <option value="{{ label }}">{{ label }}</option>
@@ -438,9 +435,8 @@
     function readCorrectInfo(container) {
       const orderedEl = container.querySelector(".js-correct-ordered");
       if (container.dataset.correctArray === "1") {
-        const list = Array.from(container.querySelectorAll(".js-correct-rows .js-correct-select"))
-          .map((s) => s.value)
-          .filter((v) => v !== "");
+        let list = [];
+        try { list = JSON.parse(container.dataset.correctList || "[]"); } catch (e) {}
         return { mode: "array", list: list, ordered: !!(orderedEl && orderedEl.checked) };
       }
       const single = container.querySelector(".js-correct-single");
@@ -531,26 +527,54 @@
       try { saved = JSON.parse(localStorage.getItem(storageKey) || "null"); } catch (e) {}
 
       if (isArrayField) {
-        const rowsEl = container.querySelector(".js-correct-rows");
-        const template = container.querySelector(".js-correct-row-template");
+        // 入力ページと同じバッジ式UI（セレクトで選んで追加し、選択値はチップ表示）
+        const addSelect = container.querySelector(".js-correct-add-select");
         const addBtn = container.querySelector(".js-correct-add");
-        const validValues = Array.from(
-          template.content.querySelectorAll(".js-correct-select option")
-        ).map((o) => o.value);
+        const badgesEl = container.querySelector(".js-correct-badges");
+        const isUnique = container.dataset.correctUnique === "1";
+        const validValues = Array.from(addSelect.options).map((o) => o.value);
+        let selected = [];
 
-        function addRow(value) {
-          const node = template.content.firstElementChild.cloneNode(true);
-          const select = node.querySelector(".js-correct-select");
-          if (value && validValues.includes(value)) select.value = value;
-          select.addEventListener("change", onChange);
-          node.querySelector(".js-correct-remove").addEventListener("click", () => {
-            node.remove();
-            onChange();
-          });
-          rowsEl.appendChild(node);
+        function labelFor(value) {
+          const opt = Array.from(addSelect.options).find((o) => o.value === value);
+          return opt ? opt.textContent : value;
         }
 
-        addBtn.addEventListener("click", () => addRow(""));
+        function syncDataset() {
+          container.dataset.correctList = JSON.stringify(selected);
+        }
+
+        function renderBadges() {
+          badgesEl.replaceChildren();
+          selected.forEach((value, index) => {
+            const chip = document.createElement("button");
+            chip.type = "button";
+            chip.className = "inline-flex max-w-full items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs text-slate-700 hover:border-rose-300 hover:text-rose-700";
+            chip.title = "クリックして削除";
+            chip.textContent = labelFor(value) + " ×";
+            chip.addEventListener("click", () => {
+              selected.splice(index, 1);
+              syncDataset();
+              renderBadges();
+              onChange();
+            });
+            badgesEl.appendChild(chip);
+          });
+        }
+
+        function addValue(value) {
+          if (!value) return;
+          if (isUnique && selected.includes(value)) return;
+          selected.push(value);
+          syncDataset();
+          renderBadges();
+        }
+
+        addBtn.addEventListener("click", () => {
+          addValue(addSelect.value);
+          addSelect.value = "";
+          onChange();
+        });
         if (orderedEl) orderedEl.addEventListener("change", onChange);
 
         // 復元（新旧フォーマット対応）
@@ -559,7 +583,9 @@
         if (Array.isArray(saved)) { list = saved; }
         else if (saved && saved.mode === "array") { list = saved.list || []; ordered = !!saved.ordered; }
         else if (saved && Array.isArray(saved.options)) { list = saved.options; ordered = !!saved.ordered; }
-        list.forEach((v) => addRow(v));
+        selected = list.filter((v) => validValues.includes(v));
+        syncDataset();
+        renderBadges();
         if (orderedEl) orderedEl.checked = ordered;
       } else {
         const single = container.querySelector(".js-correct-single");

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -12,6 +12,7 @@
       <input type="file" id="import-file-input" name="file" accept=".csv,.tsv" required class="hidden" />
       <button type="button" id="open-import-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">取り込み</button>
     </form>
+    <a href="/forms/{{ form.id }}/aggregate?{{ build_query(query, page=None) }}" class="rounded border border-slate-300 px-3 py-2 text-sm">集計</a>
     <a href="/f/{{ form.public_id }}" class="rounded border border-slate-300 px-3 py-2 text-sm">入力ページ</a>
     <button type="button" id="open-download-modal" class="rounded border border-slate-300 px-3 py-2 text-sm">ダウンロード</button>
   </div>


### PR DESCRIPTION
## Summary
This PR adds a comprehensive aggregation and analytics view for form submissions, allowing users to visualize submission data through charts and drill down into filtered results.

## Key Changes

### New Features
- **Aggregation Dashboard** (`/forms/{form_id}/aggregate`): New page displaying analytics for form submissions with:
  - Time series chart showing submission counts over time with configurable granularity (auto, year, month, week, day, hour, minute, second)
  - Distribution charts for enum and boolean fields (toggleable between bar and pie charts)
  - Statistics tables for numeric fields (count, sum, average, min, max) with histograms
  - Correct answer tracking for quiz-like forms with answer rate calculations
  
- **Interactive Drill-Down**: Click on chart elements to filter the data table below, showing only submissions matching that selection with visual feedback

- **Data Export**: Download filtered/aggregated data in multiple formats (Excel, CSV, Parquet, JSON) with optional correct answer columns

### Implementation Details

**New Modules:**
- `src/schemaform/aggregate.py`: Core aggregation logic including:
  - `aggregate_submissions()`: Main function to compute statistics and distributions
  - `build_histogram()`: Intelligent histogram generation with equal-width binning
  - `_distribution_enum()`, `_distribution_boolean()`, `_numeric()`: Field-specific aggregation
  - `to_utc_iso()`: UTC timestamp normalization for client-side time bucketing
  
- `src/schemaform/routes/aggregate.py`: Route handler for the aggregation view

**Enhanced Modules:**
- `src/schemaform/routes/submissions.py`:
  - `gather_filtered_submissions()`: Extracted common submission filtering logic (used by submissions list, export, and aggregation)
  - `build_full_table_context()`: New helper to build full table data without pagination
  - `resolve_user_display_map()` and `resolve_user_label()`: Extracted user display name resolution
  - `_parse_correct_map()` and `_row_is_correct()`: New functions to handle correct answer specifications from the aggregation view
  - `_correctness_cells()`: Compute correct answer count and percentage for export

**Template:**
- `templates/aggregate.html`: 920-line template with:
  - Chart.js integration for interactive visualizations
  - Time series chart with automatic granularity selection
  - Distribution and numeric field charts with drill-down capability
  - Data table with sorting and drill-down filtering
  - Download modal for exporting filtered data
  - Correct answer configuration UI for enum/array fields

**UI Integration:**
- Added "集計" (Aggregation) link in submissions list navigation
- Download modal reused from submissions list with query parameter support

### Technical Highlights
- Client-side time bucketing with automatic granularity selection based on data density
- Intelligent histogram binning that falls back to exact value matching for small integer ranges
- Drill-down filtering that preserves query parameters and supports both time-based and value-based predicates
- Correct answer tracking supports both single-select and multi-select (ordered/unordered) fields
- File preview and URL detection in data table cells (reuses existing submission display logic)

https://claude.ai/code/session_01CNwkLhPH4WETYEA3cb7T7F