### PR TITLE
Excelエクスポートの全セルの縦位置を中央揃えにする

### DIFF
--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -941,6 +941,7 @@ def _serialize_export(
         center_wrap_align = Alignment(vertical="center", wrap_text=True)
         header_font = Font(bold=True)
         workbook = Workbook()
+        workbook._named_styles["Normal"].alignment = center_align
         worksheet = workbook.active
         worksheet.title = "submissions"
         worksheet.append(headers)

--- a/src/schemaform/routes/submissions.py
+++ b/src/schemaform/routes/submissions.py
@@ -993,7 +993,9 @@ def _serialize_export(
             # Pad for cell margins plus the header's filter dropdown arrow,
             # then clamp so columns stay within a sensible range.
             width = max(8, min(content_width + 4, 60))
-            worksheet.column_dimensions[get_column_letter(col_index + 1)].width = width
+            col_dim = worksheet.column_dimensions[get_column_letter(col_index + 1)]
+            col_dim.width = width
+            col_dim.alignment = center_align
         # Enable Excel's filter dropdowns on the header row over all data.
         worksheet.auto_filter.ref = worksheet.dimensions
         buffer = io.BytesIO()


### PR DESCRIPTION
ワークブックのデフォルトスタイル（Normal）の縦位置を中央揃えに設定することで、データ範囲内外を問わず全セルのデフォルト縦位置が中央揃えになるよう修正。また、データ列のColumnDimensionにも同様のアラインメントを設定。