### PR TITLE
feat: PyInstaller による実行ファイル配布に対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Build Executables
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            artifact_suffix: linux-x86_64
+          - os: windows-latest
+            artifact_suffix: windows-x86_64
+          - os: macos-13
+            artifact_suffix: macos-x86_64
+          - os: macos-latest
+            artifact_suffix: macos-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install PyInstaller
+        run: uv pip install pyinstaller
+
+      - name: Build executable
+        run: uv run pyinstaller schemaform.spec
+
+      - name: Rename artifact (Linux / macOS)
+        if: runner.os != 'Windows'
+        run: mv dist/schemaform dist/schemaform-${{ matrix.artifact_suffix }}
+
+      - name: Rename artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Move-Item dist\schemaform.exe dist\schemaform-${{ matrix.artifact_suffix }}.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: schemaform-${{ matrix.artifact_suffix }}
+          path: dist/schemaform-${{ matrix.artifact_suffix }}*
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
           - os: windows-latest
             artifact_suffix: windows-x86_64
           - os: macos-latest
-            artifact_suffix: macos-arm64
-            # macOS arm64 バイナリは Rosetta 2 により Intel Mac でも動作するため
-            # x86_64 向け別ビルド（macos-13: 割り当てが遅い）は不要
+            artifact_suffix: macos-universal2
+            # arm64 + x86_64 両スライスを同一ランナー上でビルドし
+            # lipo で universal2 に合成（macos-13 ランナー不要）
 
     runs-on: ${{ matrix.os }}
 
@@ -52,11 +52,13 @@ jobs:
           --format=markdown
           --output-file=THIRD_PARTY_LICENSES.txt
 
-      - name: Build executable
+      # ── Linux / Windows: 通常ビルド ────────────────────────────────
+      - name: Build executable (Linux / Windows)
+        if: runner.os != 'macOS'
         run: uv run pyinstaller schemaform.spec
 
-      - name: Rename artifact (Linux / macOS)
-        if: runner.os != 'Windows'
+      - name: Rename artifact (Linux)
+        if: runner.os == 'Linux'
         run: mv dist/schemaform dist/schemaform-${{ matrix.artifact_suffix }}
 
       - name: Rename artifact (Windows)
@@ -64,6 +66,37 @@ jobs:
         shell: pwsh
         run: Move-Item dist\schemaform.exe dist\schemaform-${{ matrix.artifact_suffix }}.exe
 
+      # ── macOS: arm64 + x86_64 → lipo で universal2 ──────────────
+      - name: Build arm64 slice (macOS)
+        if: runner.os == 'macOS'
+        run: uv run pyinstaller schemaform.spec --distpath dist_arm64
+
+      - name: Install x86_64 uv and build x86_64 slice via Rosetta2 (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          UV_VERSION=$(uv --version | awk '{print $2}')
+          curl -fsSL -o /tmp/uv-x86.tar.gz \
+            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz"
+          mkdir -p /tmp/uv-x86
+          tar -xzf /tmp/uv-x86.tar.gz -C /tmp/uv-x86
+
+          # x86_64 uv で x86_64 venv を作成し依存関係をインストール
+          /tmp/uv-x86/uv venv .venv-x86_64 --python 3.12
+          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" /tmp/uv-x86/uv sync
+          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" /tmp/uv-x86/uv pip install pyinstaller
+
+          # x86_64 バイナリをビルド
+          .venv-x86_64/bin/pyinstaller schemaform.spec --distpath dist_x86_64
+
+      - name: Create universal2 binary with lipo (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p dist
+          lipo -create dist_arm64/schemaform dist_x86_64/schemaform \
+               -output dist/schemaform-${{ matrix.artifact_suffix }}
+          lipo -info dist/schemaform-${{ matrix.artifact_suffix }}
+
+      # ── 成果物アップロード ─────────────────────────────────────────
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
             artifact_suffix: linux-x86_64
           - os: windows-latest
             artifact_suffix: windows-x86_64
-          - os: macos-13
-            artifact_suffix: macos-x86_64
           - os: macos-latest
             artifact_suffix: macos-arm64
+            # macOS arm64 バイナリは Rosetta 2 により Intel Mac でも動作するため
+            # x86_64 向け別ビルド（macos-13: 割り当てが遅い）は不要
 
     runs-on: ${{ matrix.os }}
 
@@ -37,8 +37,20 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Install PyInstaller
-        run: uv pip install pyinstaller
+      - name: Install PyInstaller and pip-licenses
+        run: uv pip install pyinstaller pip-licenses
+
+      - name: Generate third-party license texts
+        # --with-license-file で全ライセンス本文を取得。失敗時はライセンス名のみで続行
+        run: >
+          uv run pip-licenses
+          --format=plain-vertical
+          --with-license-file
+          --no-license-path
+          --output-file=THIRD_PARTY_LICENSES.txt
+          || uv run pip-licenses
+          --format=markdown
+          --output-file=THIRD_PARTY_LICENSES.txt
 
       - name: Build executable
         run: uv run pyinstaller schemaform.spec
@@ -64,7 +76,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies and pip-licenses
+        run: uv sync && uv pip install pip-licenses
+
+      - name: Generate third-party license texts
+        run: >
+          uv run pip-licenses
+          --format=plain-vertical
+          --with-license-file
+          --no-license-path
+          --output-file=THIRD_PARTY_LICENSES.txt
+          || uv run pip-licenses
+          --format=markdown
+          --output-file=THIRD_PARTY_LICENSES.txt
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
@@ -72,4 +106,10 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
+          files: |
+            dist/*
+            LICENSE
+            LICENSE-MIT
+            LICENSE-APACHE
+            THIRD_PARTY_NOTICES.md
+            THIRD_PARTY_LICENSES.txt

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,28 +1,73 @@
 # Third-Party Notices
 
-This project uses third-party components. License texts and required notices are available at the listed URLs. When distributing this software, include the applicable license texts and any required copyright notices.
+This project uses third-party components. When distributing this software (including
+as a compiled executable), you must include the applicable license texts and copyright
+notices. Full license texts for all bundled dependencies are generated at build time
+as `THIRD_PARTY_LICENSES.txt` and are included in the GitHub Release.
 
-## Python dependencies (pyproject.toml)
-- FastAPI — MIT — https://pypi.org/project/fastapi/
-- Uvicorn — BSD License — https://pypi.org/project/uvicorn/
-- Jinja2 — BSD License — https://pypi.org/project/Jinja2/
-- python-multipart — Apache-2.0 — https://pypi.org/project/python-multipart/
-- jsonschema — MIT — https://pypi.org/project/jsonschema/
-- SQLAlchemy — MIT — https://pypi.org/project/sqlalchemy/
-- aiosqlite — MIT — https://pypi.org/project/aiosqlite/
-- TinyDB — MIT — https://pypi.org/project/tinydb/
-- filelock — The Unlicense — https://pypi.org/project/filelock/
-- orjson — MPL-2.0 / Apache-2.0 / MIT (mixed; see upstream) — https://pypi.org/project/orjson/
-- ulid-py — Apache-2.0 — https://pypi.org/project/ulid-py/
-- Typer — MIT — https://pypi.org/project/typer/
-- httpx — BSD License — https://pypi.org/project/httpx/
-- user-permission — MIT — https://pypi.org/project/user-permission/
-- openpyxl — MIT — https://pypi.org/project/openpyxl/
-- pyarrow — Apache-2.0 — https://pypi.org/project/pyarrow/
+## Direct dependencies (pyproject.toml)
+
+- FastAPI — MIT — https://github.com/fastapi/fastapi
+- Uvicorn — BSD 3-Clause — https://github.com/encode/uvicorn
+- Jinja2 — BSD 3-Clause — https://github.com/pallets/jinja
+- python-multipart — Apache-2.0 — https://github.com/Kludex/python-multipart
+- jsonschema — MIT — https://github.com/python-jsonschema/jsonschema
+- SQLAlchemy — MIT — https://github.com/sqlalchemy/sqlalchemy
+- aiosqlite — MIT — https://github.com/omnilib/aiosqlite
+- TinyDB — MIT — https://github.com/msiemens/tinydb
+- filelock — The Unlicense — https://github.com/tox-dev/filelock
+- orjson — Apache-2.0 / MIT — https://github.com/ijl/orjson
+- ulid-py — Apache-2.0 — https://github.com/ahawker/ulid
+- Typer — MIT — https://github.com/fastapi/typer
+- httpx — BSD 3-Clause — https://github.com/encode/httpx
+- user-permission — MIT — https://github.com/mokuichi147/user-permission
+- openpyxl — MIT — https://foss.heptapod.net/openpyxl/openpyxl
+- pyarrow — Apache-2.0 — https://github.com/apache/arrow
+
+## Key transitive dependencies also bundled in the executable
+
+- Starlette — BSD 3-Clause — https://github.com/encode/starlette
+- Pydantic — MIT — https://github.com/pydantic/pydantic
+- pydantic-core — MIT — https://github.com/pydantic/pydantic-core
+- Click — BSD 3-Clause — https://github.com/pallets/click
+- Rich — MIT — https://github.com/Textualize/rich
+- AnyIO — MIT — https://github.com/agronholm/anyio
+- httpcore — BSD 3-Clause — https://github.com/encode/httpcore
+- h11 — MIT — https://github.com/python-hyper/h11
+- certifi — MPL-2.0 — https://github.com/certifi/python-certifi
+- idna — BSD-like — https://github.com/kjd/idna
+- sniffio — MIT / Apache-2.0 — https://github.com/python-trio/sniffio
+- greenlet — MIT — https://github.com/python-greenlet/greenlet
+- MarkupSafe — BSD 3-Clause — https://github.com/pallets/markupsafe
+- attrs — MIT — https://github.com/python-attrs/attrs
+- jsonschema-specifications — MIT — https://github.com/python-jsonschema/jsonschema-specifications
+- referencing — MIT — https://github.com/python-jsonschema/referencing
+- rpds-py — MIT — https://github.com/crate-py/rpds
+- annotated-types — MIT — https://github.com/annotated-types/annotated-types
+- typing_extensions — PSF-2.0 — https://github.com/python/typing_extensions
+- typing-inspection — MIT — https://github.com/pydantic/typing-inspection
+- shellingham — MIT — https://github.com/sarugaku/shellingham
+- colorama — BSD 3-Clause — https://github.com/tartley/colorama
+- Pygments — BSD 2-Clause — https://github.com/pygments/pygments
+- markdown-it-py — MIT — https://github.com/executablebooks/markdown-it-py
+- mdurl — MIT — https://github.com/executablebooks/mdurl
+- et-xmlfile — MIT — https://foss.heptapod.net/openpyxl/et_xmlfile
+- PyInstaller bootloader — Apache-2.0 (with distribution exception) — https://github.com/pyinstaller/pyinstaller
 
 ## Frontend CDN libraries
+
 - Tailwind CSS — MIT — https://github.com/tailwindlabs/tailwindcss
-- htmx — BSD 2-Clause — https://unpkg.com/htmx.org@1.9.12/LICENSE
+- htmx — BSD 2-Clause — https://htmx.org
 - SortableJS — MIT — https://github.com/SortableJS/Sortable
 - flatpickr — MIT — https://github.com/flatpickr/flatpickr
 - Chart.js — MIT — https://github.com/chartjs/Chart.js
+
+## Notes on specific licenses
+
+**MPL-2.0 (certifi):** The Mozilla Public License 2.0 allows distribution of certifi as
+part of a larger work. The source code for certifi is available at
+https://github.com/certifi/python-certifi. No modifications were made to certifi.
+
+**PyInstaller bootloader:** PyInstaller ≥ 4.2 ships a bootloader under Apache-2.0 with
+an explicit exception permitting distribution in executables of any license. The bundled
+executable is therefore not subject to GPL restrictions.

--- a/schemaform.spec
+++ b/schemaform.spec
@@ -1,4 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
+import os
 from PyInstaller.utils.hooks import collect_all, collect_data_files
 
 block_cipher = None
@@ -12,6 +13,17 @@ datas += [
     ("templates", "templates"),
     ("static", "static"),
 ]
+
+# プロジェクト自身のライセンスファイルを同梱（配布時の表示義務を満たすため）
+datas += [
+    ("LICENSE", "."),
+    ("LICENSE-MIT", "."),
+    ("LICENSE-APACHE", "."),
+    ("THIRD_PARTY_NOTICES.md", "."),
+]
+# ビルド時に生成された依存ライブラリのライセンス全文ファイルを同梱
+if os.path.exists("THIRD_PARTY_LICENSES.txt"):
+    datas += [("THIRD_PARTY_LICENSES.txt", ".")]
 
 # 動的インポートを多用するパッケージを丸ごと収集
 for _pkg in [

--- a/schemaform.spec
+++ b/schemaform.spec
@@ -1,0 +1,86 @@
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import collect_all, collect_data_files
+
+block_cipher = None
+
+datas = []
+binaries = []
+hiddenimports = []
+
+# templates / static をバンドルに含める
+datas += [
+    ("templates", "templates"),
+    ("static", "static"),
+]
+
+# 動的インポートを多用するパッケージを丸ごと収集
+for _pkg in [
+    "uvicorn",
+    "fastapi",
+    "starlette",
+    "aiosqlite",
+    "sqlalchemy",
+    "jsonschema",
+    "user_permission",
+    "openpyxl",
+    "pyarrow",
+]:
+    _d, _b, _h = collect_all(_pkg)
+    datas += _d
+    binaries += _b
+    hiddenimports += _h
+
+a = Analysis(
+    ["src/schemaform/__main__.py"],
+    pathex=["src"],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports
+    + [
+        "sqlalchemy.dialects.sqlite",
+        "sqlalchemy.dialects.sqlite.aiosqlite",
+        "multipart",
+        "jinja2",
+        "jinja2.ext",
+        "orjson",
+        "ulid",
+        "typer",
+        "filelock",
+        "tinydb",
+        "tinydb.storages",
+        "tinydb.middlewares",
+        "httpx",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="schemaform",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/src/schemaform/config.py
+++ b/src/schemaform/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from pathlib import Path
 
 ALLOWED_TYPES = {
@@ -20,7 +21,14 @@ ALLOWED_TYPES = {
 }
 KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+def _get_base_dir() -> Path:
+    # PyInstaller で --onefile ビルドした場合、実行時に sys._MEIPASS へ展開される
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS)
+    return Path(__file__).resolve().parent.parent.parent
+
+
+BASE_DIR = _get_base_dir()
 
 
 class Settings:


### PR DESCRIPTION
- config.py: sys._MEIPASS を参照し、PyInstaller --onefile ビルド時に
  templates/static ディレクトリを正しく解決できるよう BASE_DIR を修正
- schemaform.spec: PyInstaller スペックファイルを追加
  (templates・static を同梱、uvicorn/fastapi 等の動的インポートに対応)
- .github/workflows/build.yml: Linux/Windows/macOS 向け実行ファイルを
  GitHub Actions でビルドし、タグプッシュ時に GitHub Release へ自動公開

https://claude.ai/code/session_019UUdormewBswDnZnsSBrqZ