### PR TITLE
feat: 実行ファイル形式での配布に対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,14 @@ jobs:
             "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz"
           mkdir -p /tmp/uv-x86
           tar -xzf /tmp/uv-x86.tar.gz -C /tmp/uv-x86
+          # アーカイブ内のサブディレクトリ構造に依存しないよう find で探す
+          UV_X86=$(find /tmp/uv-x86 -name uv -type f | head -1)
+          chmod +x "$UV_X86"
 
           # x86_64 uv で x86_64 venv を作成し依存関係をインストール
-          /tmp/uv-x86/uv venv .venv-x86_64 --python 3.12
-          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" /tmp/uv-x86/uv sync
-          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" /tmp/uv-x86/uv pip install pyinstaller
+          "$UV_X86" venv .venv-x86_64 --python 3.12
+          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" "$UV_X86" sync
+          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" "$UV_X86" pip install pyinstaller
 
           # x86_64 バイナリをビルド
           .venv-x86_64/bin/pyinstaller schemaform.spec --distpath dist_x86_64


### PR DESCRIPTION
## 概要

PyInstaller を使って単一実行ファイルとして配布できるようにしました。GitHub Actions でタグをプッシュすると Linux / Windows / macOS 向けのバイナリが自動ビルドされ、GitHub Release に公開されます。

## 変更内容

### `src/schemaform/config.py`
- PyInstaller の `--onefile` ビルド時に `sys._MEIPASS` を参照するよう `BASE_DIR` を修正
- バンドル時でも `templates/` と `static/` を正しく解決できる

### `schemaform.spec`
- PyInstaller スペックファイルを追加
- `templates/`・`static/` を実行ファイルに同梱
- uvicorn / fastapi / sqlalchemy 等、動的インポートを使うパッケージを `collect_all` で網羅的に収集
- `LICENSE`・`LICENSE-MIT`・`LICENSE-APACHE`・`THIRD_PARTY_NOTICES.md`・`THIRD_PARTY_LICENSES.txt` をバンドルに同梱（ライセンス表示義務を満たすため）

### `THIRD_PARTY_NOTICES.md`
- 間接依存 27 パッケージ（starlette, pydantic, certifi など）を追記
- certifi (MPL-2.0) および PyInstaller ブートローダーのライセンスに関する補足説明を追加

### `.github/workflows/build.yml`
- タグ（`v*`）プッシュ時および手動トリガー（`workflow_dispatch`）でビルドを実行
- ビルドターゲット：
  - `schemaform-linux-x86_64`
  - `schemaform-windows-x86_64.exe`
  - `schemaform-macos-universal2`（Intel + Apple Silicon 両対応）
- macOS は `macos-latest`（arm64）のみ使用。x86_64 uv を Rosetta2 経由で実行して x86_64 スライスをビルドし、`lipo` で universal2 に合成（`macos-13` ランナー不要）
- `pip-licenses` でビルド時に全依存のライセンス本文を生成し、実行ファイルへの同梱と GitHub Release への添付を自動化

## リリース方法

```bash
git tag v1.0.0
git push origin v1.0.0
```

タグをプッシュすると Actions が起動し、3プラットフォーム分のバイナリと LICENSE 関連ファイルが GitHub Release に自動公開されます。

---
_Generated by [Claude Code](https://claude.ai/code/session_019UUdormewBswDnZnsSBrqZ)_