### PR TITLE
fix: x86_64 venv への pyinstaller インストールを修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,8 @@ jobs:
           # x86_64 uv で x86_64 venv を作成し依存関係をインストール
           "$UV_X86" venv .venv-x86_64 --python 3.12
           UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" "$UV_X86" sync
-          UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-x86_64" "$UV_X86" pip install pyinstaller
+          # uv pip install は UV_PROJECT_ENVIRONMENT を無視するため VIRTUAL_ENV で明示指定
+          VIRTUAL_ENV="$(pwd)/.venv-x86_64" "$UV_X86" pip install pyinstaller
 
           # x86_64 バイナリをビルド
           .venv-x86_64/bin/pyinstaller schemaform.spec --distpath dist_x86_64


### PR DESCRIPTION
## 概要

macOS universal2 ビルドで x86_64 スライスのビルドが失敗していた問題を修正します。

## 原因

`uv pip install` は `UV_PROJECT_ENVIRONMENT` を参照せず、setup-uv がセットした `VIRTUAL_ENV=.venv`（arm64 venv）を参照するため、pyinstaller が x86_64 用の `.venv-x86_64` ではなく arm64 用の `.venv` にインストールされていました。その結果 `.venv-x86_64/bin/pyinstaller` が存在せずビルドが失敗していました。

## 修正内容

`VIRTUAL_ENV="$(pwd)/.venv-x86_64"` を明示的に指定することで、x86_64 venv への pyinstaller インストールを確実に行うよう修正しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_019UUdormewBswDnZnsSBrqZ)_