### PR TITLE
fix: セッション切れ時にエラーではなくログイン画面へ誘導

### DIFF
--- a/src/schemaform/app.py
+++ b/src/schemaform/app.py
@@ -8,9 +8,13 @@ from urllib.parse import urlencode
 
 import markupsafe
 from fastapi import FastAPI, Request
-from fastapi.responses import RedirectResponse
+from fastapi.exception_handlers import (
+    http_exception_handler as default_http_exception_handler,
+)
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from schemaform.auth import LoginRequired, get_auth_provider
 from schemaform.config import BASE_DIR, Settings, ensure_dirs
@@ -308,6 +312,60 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         next_q = urlencode({"next": exc.next_path}) if exc.next_path else ""
         target = f"/login?{next_q}" if next_q else "/login"
         return RedirectResponse(target, status_code=303)
+
+    default_error_messages = {
+        400: "リクエストの内容が正しくありません",
+        403: "この操作を行う権限がありません",
+        404: "ページが見つかりません",
+        500: "サーバーでエラーが発生しました",
+    }
+
+    def render_error_page(
+        request: Request, status_code: int, message: str | None = None
+    ) -> Response:
+        text = message or default_error_messages.get(
+            status_code, "エラーが発生しました"
+        )
+        return templates.TemplateResponse(
+            "error.html",
+            {
+                "request": request,
+                "status_code": status_code,
+                "message": text,
+                "title": f"{status_code} エラー",
+            },
+            status_code=status_code,
+        )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ):
+        accepts_html = "text/html" in request.headers.get("accept", "")
+        # セッション切れ等で未ログインの状態で 401/403 に当たった HTML 画面は、
+        # ログインページへ誘導する。
+        if exc.status_code in (401, 403):
+            user = getattr(request.state, "current_user", None)
+            if accepts_html and user is None and get_auth_enabled(request):
+                path = request.url.path
+                if request.url.query:
+                    path = f"{path}?{request.url.query}"
+                next_q = urlencode({"next": path})
+                return RedirectResponse(f"/login?{next_q}", status_code=303)
+        # それ以外の HTML リクエストには、生の JSON ではなく整形した
+        # エラーページを返す。
+        if accepts_html:
+            detail = exc.detail if isinstance(exc.detail, str) else None
+            return render_error_page(request, exc.status_code, detail)
+        return await default_http_exception_handler(request, exc)
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        if "text/html" in request.headers.get("accept", ""):
+            return render_error_page(request, 500)
+        return JSONResponse(
+            {"detail": "Internal Server Error"}, status_code=500
+        )
 
     app.include_router(auth_router)
     app.include_router(admin_router)

--- a/src/schemaform/auth.py
+++ b/src/schemaform/auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import time
 from datetime import timedelta
 from typing import Any, Protocol
 
@@ -163,6 +164,13 @@ class UserPermissionAuthProvider:
                 payload = _decode_jwt_payload_unverified(token)
                 if payload is None or "sub" not in payload:
                     return None
+                exp = payload.get("exp")
+                if exp is not None:
+                    try:
+                        if time.time() >= float(exp):
+                            return None
+                    except (TypeError, ValueError):
+                        return None
                 user_id = int(payload["sub"])
                 user = await self._db.users.get_by_id(user_id, token=token)
                 if user is None:

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="mx-auto max-w-md text-center">
+  <p class="text-5xl font-bold text-slate-300">{{ status_code }}</p>
+  <h1 class="mt-4 text-xl font-semibold">{{ message }}</h1>
+  <div class="mt-8">
+    <a href="/forms" class="inline-block rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700">
+      フォーム一覧へ戻る
+    </a>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## 概要

JWTの期限切れや別タブでのログアウト後にページを読み込み直すと、黒背景の生エラーJSON（例: `{"detail":"このフォームを閲覧する権限がありません"}`）が表示され、ページが描画されない問題を修正します。セッションが無効な状態でのアクセスは、エラーを見せずにログイン画面へ誘導します。

## 背景・原因

- リレー認証（`--auth-db` が `http(s)://...`）では JWT を署名検証なしでデコードしており、有効期限（`exp`）を確認していなかった。
- そのため期限切れトークンでも `sub` が取れれば「ログイン済み・グループ空」の状態で `current_user` がセットされ、結果「ログイン済みだが権限なし」→ `403` となり、ログイン画面に飛ばずエラー表示になっていた。

## 変更内容

- **`auth.py`**: リレー経路で JWT `exp` をローカル検証し、期限切れは未ログイン扱いに。（ローカルDB認証は元々 `verify_token` で期限検証済み）
- **`app.py`**: 未認証（401/403 かつ `current_user` なし）の HTML アクセスを `/login?next=元URL` へリダイレクト。ログイン後は元ページへ戻る。
- **`app.py` / `templates/error.html`**: 上記に該当しない真のエラー（500 など）は、生の JSON ではなく整形したエラーページを表示。APIクライアント（`Accept: application/json`）は従来通り JSON を返す。

## 動作確認

| シナリオ | 結果 |
|---|---|
| 期限切れトークン + 保護ページ（HTML） | `303 → /login?next=...` |
| 別タブでログアウト（クッキー消滅）後にアクセス | `303 → /login?next=...` |
| ローカルDB認証の期限切れ | `verify_token` で検知し同様に誘導 |
| 匿名許可フォーム | 従来通り描画 |
| APIクライアント（JSON） | 従来通り JSON |

## レビュー観点

- リレー認証で `exp` をローカル検証する追加が、署名検証はリレー側に委ねる既存方針と整合しているか。
- 401/403 のリダイレクトを `current_user is None` の場合に限定しており、ログイン済みで権限不足の場合はリダイレクトループを避けて整形エラーページを表示する点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)