### PR TITLE
環境変数に SCHEMAFORM_ プレフィックスを付与し未使用の AUTH_MODE を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,18 @@ curl -i "http://localhost:8000/api/forms/<form_id>/submissions?limit=50"
 ```
 
 ## 環境変数
-- `STORAGE_BACKEND=sqlite|json`
-- `SQLITE_PATH=./data/app.db`
-- `JSON_PATH=./data/jsonstore.json`
-- `UPLOAD_DIR=./data/uploads`
-- `UPLOAD_MAX_BYTES`（未指定なら無制限）
-- `FILE_URL_SECRET=./data/file_url.secret`（`/files/{file_id}` の署名付きURL生成に使う秘密鍵ファイル。未存在なら自動生成）
-- `FILE_URL_TTL_SECONDS=86400`（署名付きファイルURLの有効期間。デフォルト24時間）
-- `AUTH_MODE=none|ldap`（ldapは未実装）
-- `PASSWORD_MIN_LENGTH=8`（アカウント作成・パスワード変更時の最小文字数）
-- `HOST=0.0.0.0`
-- `PORT=8000`
+他サービスと衝突しないよう、すべて `SCHEMAFORM_` プレフィックスを付けています。
+
+- `SCHEMAFORM_STORAGE_BACKEND=sqlite|json`
+- `SCHEMAFORM_SQLITE_PATH=./data/app.db`
+- `SCHEMAFORM_JSON_PATH=./data/jsonstore.json`
+- `SCHEMAFORM_UPLOAD_DIR=./data/uploads`
+- `SCHEMAFORM_UPLOAD_MAX_BYTES`（未指定なら無制限）
+- `SCHEMAFORM_FILE_URL_SECRET=./data/file_url.secret`（`/files/{file_id}` の署名付きURL生成に使う秘密鍵ファイル。未存在なら自動生成）
+- `SCHEMAFORM_FILE_URL_TTL_SECONDS=86400`（署名付きファイルURLの有効期間。デフォルト24時間）
+- `SCHEMAFORM_PASSWORD_MIN_LENGTH=8`（アカウント作成・パスワード変更時の最小文字数）
+- `SCHEMAFORM_HOST=0.0.0.0`
+- `SCHEMAFORM_PORT=8000`
 
 ## JsonSchema 対応範囲
 - `string | number | integer | boolean | enum | array(items=primitive|file)`

--- a/src/schemaform/config.py
+++ b/src/schemaform/config.py
@@ -33,54 +33,56 @@ BASE_DIR = _get_base_dir()
 
 class Settings:
     def __init__(self) -> None:
-        self.storage_backend = os.getenv("STORAGE_BACKEND", "sqlite").lower()
-        self.sqlite_path = Path(os.getenv("SQLITE_PATH", "./data/app.db"))
-        self.json_path = Path(os.getenv("JSON_PATH", "./data/jsonstore.json"))
-        self.upload_dir = Path(os.getenv("UPLOAD_DIR", "./data/uploads"))
-        max_bytes = os.getenv("UPLOAD_MAX_BYTES")
+        self.storage_backend = os.getenv("SCHEMAFORM_STORAGE_BACKEND", "sqlite").lower()
+        self.sqlite_path = Path(os.getenv("SCHEMAFORM_SQLITE_PATH", "./data/app.db"))
+        self.json_path = Path(
+            os.getenv("SCHEMAFORM_JSON_PATH", "./data/jsonstore.json")
+        )
+        self.upload_dir = Path(os.getenv("SCHEMAFORM_UPLOAD_DIR", "./data/uploads"))
+        max_bytes = os.getenv("SCHEMAFORM_UPLOAD_MAX_BYTES")
         self.upload_max_bytes = int(max_bytes) if max_bytes else None
-        self.solo = os.getenv("SOLO", "").lower() in ("1", "true", "yes")
-        db_value = os.getenv("USER_PERMISSION_DB")
+        self.solo = os.getenv("SCHEMAFORM_SOLO", "").lower() in ("1", "true", "yes")
+        db_value = os.getenv("SCHEMAFORM_USER_PERMISSION_DB")
         self.user_permission_db: str = db_value or "./data/users.db"
         self.user_permission_secret = Path(
-            os.getenv("USER_PERMISSION_SECRET", "./data/users.secret")
+            os.getenv("SCHEMAFORM_USER_PERMISSION_SECRET", "./data/users.secret")
         )
         self.file_url_secret = Path(
-            os.getenv("FILE_URL_SECRET", "./data/file_url.secret")
+            os.getenv("SCHEMAFORM_FILE_URL_SECRET", "./data/file_url.secret")
         )
         try:
             self.file_url_ttl_seconds = int(
-                os.getenv("FILE_URL_TTL_SECONDS", "86400")
+                os.getenv("SCHEMAFORM_FILE_URL_TTL_SECONDS", "86400")
             )
         except ValueError:
             self.file_url_ttl_seconds = 86400
         self.user_permission_admin_group = os.getenv(
-            "USER_PERMISSION_ADMIN_GROUP", "admins"
+            "SCHEMAFORM_USER_PERMISSION_ADMIN_GROUP", "admins"
         )
         self.user_permission_token_cookie = os.getenv(
-            "USER_PERMISSION_TOKEN_COOKIE", "sf_token"
+            "SCHEMAFORM_USER_PERMISSION_TOKEN_COOKIE", "sf_token"
         )
         try:
             self.user_permission_token_hours = int(
-                os.getenv("USER_PERMISSION_TOKEN_HOURS", "24")
+                os.getenv("SCHEMAFORM_USER_PERMISSION_TOKEN_HOURS", "24")
             )
         except ValueError:
             self.user_permission_token_hours = 24
-        self.allow_signup = os.getenv("ALLOW_SIGNUP", "true").lower() in (
+        self.allow_signup = os.getenv("SCHEMAFORM_ALLOW_SIGNUP", "true").lower() in (
             "1",
             "true",
             "yes",
         )
         try:
             self.password_min_length = int(
-                os.getenv("PASSWORD_MIN_LENGTH", "8")
+                os.getenv("SCHEMAFORM_PASSWORD_MIN_LENGTH", "8")
             )
         except ValueError:
             self.password_min_length = 8
         if self.password_min_length < 1:
             self.password_min_length = 1
-        self.host = os.getenv("HOST", "0.0.0.0")
-        port_value = os.getenv("PORT", "8000")
+        self.host = os.getenv("SCHEMAFORM_HOST", "0.0.0.0")
+        port_value = os.getenv("SCHEMAFORM_PORT", "8000")
         try:
             self.port = int(port_value)
         except ValueError:


### PR DESCRIPTION
## 概要
環境変数まわりの整理を行いました。

- **未使用環境変数の削除**: `AUTH_MODE`（`none|ldap`、ldap未実装）は README に記載があるだけでコードに `os.getenv` が存在しなかったため削除しました。
- **命名の衝突回避**: config.py の全環境変数に `SCHEMAFORM_` プレフィックスを付与しました。`HOST` / `PORT` / `SOLO` / `JSON_PATH` など汎用的な名前が他サービスと干渉するのを防ぎます。

## 変更内容
- `src/schemaform/config.py`: 全16変数を `SCHEMAFORM_` 接頭辞に改名（例: `STORAGE_BACKEND` → `SCHEMAFORM_STORAGE_BACKEND`）
- `README.md`: 環境変数一覧を新名称に更新し、未使用の `AUTH_MODE` を削除

## レビュアー向け補足
- これは既存デプロイの環境変数設定を破壊する変更です。本番で環境変数を設定している場合は新名称への切り替えが必要です。
- config.py の `os.getenv` 17個（改名後16変数 + cookie名デフォルト）はすべて実際に使用されており、削除対象は `AUTH_MODE` のみでした。
- デプロイ・ビルド系ファイル（.github、schemaform.spec、pyproject.toml）には環境変数参照がなく、影響範囲は config.py と README のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)